### PR TITLE
chore: require issue forms by disabling blank issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,4 +1,4 @@
-blank_issues_enabled: true
+blank_issues_enabled: false
 contact_links:
   - name: Security report
     url: https://github.com/businesslens/pdd/security/policy


### PR DESCRIPTION
## What and why

Disables the "Open a blank issue" escape hatch in the issue chooser so every issue goes through the bug or feature form, which enforce reproduction/version fields and carry the no-credentials warning. Private vulnerability reporting is now enabled on the repo, so the security route in the chooser fully works and the free-form path is no longer needed.

## Checklist

- [x] `npm run verify` passes (config-only change; templates parse).
- [x] I followed [CONTRIBUTING.md](https://github.com/businesslens/pdd/blob/main/CONTRIBUTING.md).
- [x] No secrets or private repository URLs in the diff or description.

🤖 Generated with [Claude Code](https://claude.com/claude-code)