### PR TITLE
feat: add greenfield planning and verification workflows

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
     {
       "name": "businesslens",
       "source": "./",
-      "description": "Product-Driven Design skills: initialize, plan, verify, synchronize, deepen, validate, diagnose, and publish the .businesslens/ product map.",
+      "description": "Product-Driven Development skills: initialize, plan, verify, synchronize, deepen, validate, diagnose, and publish the .businesslens/ product map.",
       "category": "engineering",
       "keywords": [
         "pdd",

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
     {
       "name": "businesslens",
       "source": "./",
-      "description": "Product-Driven Design skills: initialize, synchronize, deepen, validate, diagnose, and publish the .businesslens/ product map.",
+      "description": "Product-Driven Design skills: initialize, plan, verify, synchronize, deepen, validate, diagnose, and publish the .businesslens/ product map.",
       "category": "engineering",
       "keywords": [
         "pdd",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -17,6 +17,8 @@
   ],
   "skills": [
     "./skills/businesslens-init",
+    "./skills/businesslens-plan",
+    "./skills/businesslens-verify",
     "./skills/businesslens-sync",
     "./skills/businesslens-deep-dive",
     "./skills/businesslens-validate",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "businesslens",
   "version": "0.5.0",
-  "description": "Product-Driven Design for coding agents: build and maintain a git-tracked product map in .businesslens/.",
+  "description": "Product-Driven Development for coding agents: build and maintain a git-tracked product map in .businesslens/.",
   "author": {
     "name": "BusinessLens",
     "url": "https://github.com/businesslens"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,9 +17,26 @@ or validator behavior.
 - `src/core/` — parsers, model loading, Git evidence, portable schema, and the
   platform client.
 - `skills/businesslens-*/SKILL.md` — one independent skill per workflow:
-  `businesslens-init`, `businesslens-sync`, `businesslens-deep-dive`,
-  `businesslens-validate`, `businesslens-doctor`, and `businesslens-publish`.
+  `businesslens-init`, `businesslens-plan`, `businesslens-verify`,
+  `businesslens-sync`, `businesslens-deep-dive`, `businesslens-validate`,
+  `businesslens-doctor`, and `businesslens-publish`.
 - `test/fixtures/fixture-shop/` — the golden validation fixture.
+
+## Documentation structure
+
+- `docs/` stays flat; the landing repository pulls it on push and builds
+  the docs site navigation from frontmatter.
+- Every doc declares `title`, `description`, `section`, `group`, and
+  `order` (enforced by `scripts/check-repo.mjs`). `section` is the
+  top-level docs tab (`open-source` or `platform`); `group` is the sidebar
+  cluster; `order` is global within the section.
+- Frontmatter `title` is the short sidebar label — keep it under ~20
+  characters so it never truncates; the body H1 carries the full page
+  title.
+- This repository authors the `open-source` section with groups
+  Get started, Concepts, Tutorials, Skills (one page per skill), and
+  Reference. Platform docs live in the landing repository and follow the
+  same contract.
 
 ## Skill-writing standards
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `businesslens-plan` and `businesslens-verify` skills for planning in the
+  product map and verifying implementation evidence before merge.
+- Draft greenfield maps, with missing-evidence warnings during planning and
+  build/publish refusal until verification is complete.
+- A structured open-source documentation section with tutorials, individual
+  skill pages, and deterministic navigation frontmatter.
+
 ### Fixed
 
 - Docs dispatch sends an immutable commit-pinned revision to the landing

--- a/README.md
+++ b/README.md
@@ -5,11 +5,12 @@
 [![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](./LICENSE)
 
 **Product-Driven Design for coding agents.** BusinessLens builds a
-Git-tracked product map in `.businesslens/`: who the product serves, what they
-accomplish, and where the code proves it.
+Git-tracked product map in `.businesslens/`: who the product serves, what
+they accomplish, and where the code proves it.
 
-The map is Markdown, reviewable in pull requests, and useful without a hosted
-service.
+The map is Markdown, reviewable in pull requests, and useful without a
+hosted service. One rule holds it together: behavioral claims need code
+evidence, and a green `validate` means the map and the code agree.
 
 ```text
 .businesslens/
@@ -24,43 +25,43 @@ service.
 
 ## Getting started
 
-### 1. Install the skills
-
-Run this in the repository you want to map:
+Install the skills in the repository:
 
 ```bash
 npx businesslens@latest install
 ```
 
-The installer detects supported AI harnesses, lets you customize the
-selection, asks for project or global scope, and installs only the
-BusinessLens skills.
+The installer detects supported AI harnesses (Claude Code, Codex, Cursor,
+Gemini CLI, GitHub Copilot), lets you customize the selection, asks for
+project or global scope, and installs only the BusinessLens skills. For
+automated setup: `npx businesslens@latest install --providers claude,codex
+--scope project --yes`.
 
-For automated setup:
+Then get a map:
 
-```bash
-npx businesslens@latest install \
-  --providers claude,codex,cursor \
-  --scope project \
-  --yes
-```
+- **Existing product** — `/businesslens-init` inspects the code and builds
+  the evidence-backed map.
+- **Blank repository** — `/businesslens-plan` interviews you and authors the
+  whole product as a draft map, before any code exists.
 
-### 2. Build the map in your AI harness
+(Codex users invoke skills as `$businesslens-init` / `$businesslens-plan`.)
 
-Invoke the initialization skill:
+## The loop for every feature
+
+Planning is editing the map. Git is the change model — branches hold plans,
+pull requests review them, history archives them:
 
 ```text
-/businesslens-init
+/businesslens-plan add guest checkout   # map describes intended behavior
+… implement with your coding agent …
+/businesslens-verify                    # code checked against the plan, evidence attached
+npx businesslens validate               # green = done; CI gates the PR
 ```
 
-Codex users can invoke the same skill as `$businesslens-init`. The skill
-inspects the repository without executing its application, authors the full
-map, installs the managed `AGENTS.md` guidance, and validates the result.
-
-### 3. Review and commit
-
-Review `.businesslens/`, then commit its authored files. Generated cache files
-stay ignored.
+Between plan and verify, new journeys and scenarios without `codeRefs`
+appear as expected validation findings. `/businesslens-verify` also derives
+changed and deleted work from the map diff, so the full plan is checked.
+Code changed without a plan? `/businesslens-sync` repairs the map.
 
 ## Terminal or agent?
 
@@ -73,50 +74,49 @@ BusinessLens has two deliberate surfaces:
 | Terminal | `npx businesslens validate` | Deterministically validate the map |
 | Terminal | `npx businesslens build` | Compile the map into the portable project document |
 | Terminal | `npx businesslens publish` | Submit the map to the platform as a commit-pinned snapshot |
-| AI harness | `businesslens-init` | Build the initial map |
-| AI harness | `businesslens-sync` | Update the map after behavior changes |
-| AI harness | `businesslens-deep-dive` | Expand one journey or experience |
-| AI harness | `businesslens-validate` | Validate the map and explain every result |
-| AI harness | `businesslens-doctor` | Diagnose validation, drift, and coverage |
-| AI harness | `businesslens-publish` | Publish the map to the platform on explicit request |
+| AI harness | the eight `businesslens-*` skills | Map, plan, verify, and maintain the product truth |
 
 The installer never creates `.businesslens/` or modifies `AGENTS.md`. Those
-require repository analysis and belong to the initialization skill.
+require repository analysis and belong to the skills.
 
 ## Skills
 
 | Skill | Use it when |
 | --- | --- |
-| `businesslens-init` | Adopting BusinessLens or rebuilding an incomplete map |
-| `businesslens-sync` | Code changes affected product behavior |
+| `businesslens-init` | Adopting BusinessLens in a repository that already has code |
+| `businesslens-plan` | Planning a product (blank repo) or a feature (mapped repo) before code |
+| `businesslens-verify` | Planned map changes were implemented and need evidence-backed checking |
+| `businesslens-sync` | Code changed without a plan and the map drifted |
 | `businesslens-deep-dive` | One journey or experience needs exhaustive coverage |
 | `businesslens-validate` | The map needs a read-only deterministic check |
 | `businesslens-doctor` | The map fails validation, looks stale, or needs a health report |
 | `businesslens-publish` | The user explicitly wants the map on the platform |
 
-Every skill is self-contained and follows the open Agent Skills folder format.
-The CLI currently supports Claude Code, Codex, Cursor, Gemini CLI, and GitHub
-Copilot installation paths.
+Every skill is self-contained and follows the open Agent Skills folder
+format. Claude Code plugin users may alternatively install from this
+repository's marketplace manifest; the standalone CLI remains the primary
+installation experience.
 
-`businesslens-validate` is the read-only agent interface to the deterministic
-CLI validator. `businesslens-doctor` goes further: it investigates drift,
-coverage, and hygiene, and can repair problems when explicitly requested.
+## Documentation
 
-Claude Code plugin users may alternatively install from this repository's
-marketplace manifest. The standalone CLI remains the primary installation
-experience.
+Learn the flow:
 
-## Keep the map current
+- [Introduction](./docs/index.md) · [Installation](./docs/installation.md) ·
+  [Quickstart](./docs/quickstart.md)
+- [How it works](./docs/guide.md) · [The product map](./docs/product-map.md)
+- [Map existing code](./docs/tutorial-map-existing-product.md)
+- [Plan a new product](./docs/tutorial-plan-new-product.md)
+- [Ship a feature](./docs/tutorial-ship-a-feature.md)
+- [Recover from drift](./docs/tutorial-recover-from-drift.md)
 
-1. Before changing behavior, read the relevant experiences, journeys, and
-   scenarios.
-2. Build against the repository's SDD change when one exists.
-3. Invoke `businesslens-sync` after behavior changes.
-4. Run `npx businesslens validate`.
+Reference:
 
-PDD records what **is**. OpenSpec, spec-kit, and other SDD systems prescribe
-what **will change**. BusinessLens links that intent without copying it. See
-[PDD and SDD](./docs/pdd-and-sdd.md).
+- [Skills overview](./docs/skills.md) (one page per skill)
+- [Format contract](./docs/format.md)
+- [CLI reference](./docs/cli.md)
+- [Validation rules](./docs/validation-rules.md)
+- [CI validation and publishing](./docs/ci.md)
+- [PDD and SDD](./docs/pdd-and-sdd.md)
 
 ## Updating the skills
 
@@ -128,25 +128,15 @@ Update discovers BusinessLens-managed installations through ownership markers
 and refreshes only those skill directories. It does not touch `.businesslens/`
 or `AGENTS.md`.
 
-## Documentation
-
-- [Introduction](./docs/index.md)
-- [Quickstart](./docs/quickstart.md)
-- [`.businesslens/` format](./docs/format.md)
-- [CLI reference](./docs/cli.md)
-- [Skills reference](./docs/skills.md)
-- [CI validation and publishing](./docs/ci.md)
-- [PDD and SDD](./docs/pdd-and-sdd.md)
-
 ## Safety
 
 - Skills inspect target repositories statically; they do not run target code.
 - Installation refuses to overwrite unowned `businesslens-*` directories
   unless `--force` is explicit.
 - Updates replace only artifacts marked as BusinessLens-managed.
-- No platform connection or publishing occurs during installation or mapping;
-  publishing happens only through the explicit `publish` command or the
-  `businesslens-publish` skill.
+- No platform connection or publishing occurs during installation, mapping,
+  or planning; publishing happens only through the explicit `publish`
+  command or the `businesslens-publish` skill.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![Check](https://github.com/businesslens/pdd/actions/workflows/check.yml/badge.svg)](https://github.com/businesslens/pdd/actions/workflows/check.yml)
 [![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](./LICENSE)
 
-**Product-Driven Design for coding agents.** BusinessLens builds a
+**Product-Driven Development for coding agents.** BusinessLens builds a
 Git-tracked product map in `.businesslens/`: who the product serves, what
 they accomplish, and where the code proves it.
 

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -1,12 +1,16 @@
 ---
 title: Validate in CI
 description: Run the deterministic validator on every pull request and publish snapshots on merge.
-order: 6
+section: open-source
+group: Reference
+order: 23
 ---
 
 # Validate the map in CI
 
-Run the deterministic validator on every pull request:
+Run the deterministic validator on every pull request. Green means the map
+and the code agree — a branch that plans behavior in the map merges only
+after `businesslens-verify` attached the evidence:
 
 ```yaml
 # .github/workflows/businesslens-validate.yml

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -1,7 +1,9 @@
 ---
 title: CLI reference
 description: Commands, options, and exit codes for the businesslens CLI.
-order: 4
+section: open-source
+group: Reference
+order: 21
 ---
 
 # CLI reference
@@ -14,24 +16,19 @@ current directory.
 
 ## `install`
 
-Install the six bundled BusinessLens skills:
+Install the eight bundled BusinessLens skills:
 
 ```bash
 npx businesslens@latest install
 ```
 
-Interactive setup:
-
-1. Shows detected AI harnesses and their paths.
-2. Offers detected-only or custom provider selection.
-3. Asks for project or global scope.
-4. Installs `businesslens-init`, `businesslens-sync`,
-   `businesslens-deep-dive`, `businesslens-validate`,
-   `businesslens-doctor`, and `businesslens-publish`.
-5. Records an ownership/version marker beside the installed skills.
-
-The installer does not create `.businesslens/`, alter `AGENTS.md`, install
-hooks, connect to the platform, or publish data.
+The interactive flow detects harnesses, lets you customize the selection,
+asks for project or global scope, installs the eight `businesslens-*`
+skills, and records an ownership/version marker beside them. Supported
+providers, their paths, and scope guidance live in
+[Installation](./installation.md). The installer does not create
+`.businesslens/`, alter `AGENTS.md`, install hooks, connect to the
+platform, or publish data.
 
 Options:
 
@@ -52,19 +49,6 @@ npx businesslens@latest install \
   --scope project \
   --yes
 ```
-
-Project paths:
-
-| Provider | Skills directory |
-| --- | --- |
-| Claude Code | `.claude/skills/` |
-| Codex | `.agents/skills/` |
-| Cursor | `.cursor/skills/` |
-| Gemini CLI | `.gemini/skills/` |
-| GitHub Copilot | `.github/skills/` |
-
-Global paths respect `CLAUDE_CONFIG_DIR` and `CODEX_HOME`; other providers use
-their standard user directories.
 
 ## `update`
 
@@ -96,9 +80,15 @@ Validation checks:
 - at least one scenario per journey;
 - globally unique scenario IDs;
 - required scenario sections;
-- journey and scenario `codeRefs`;
+- journey and scenario `codeRefs` — while `coverage.md` is `status: draft`
+  (a planned, not-yet-implemented map) missing codeRefs are warnings
+  instead of errors;
 - `codeRef` paths against `git ls-files`;
 - dangling local links as warnings.
+
+On a feature branch, `needs at least one codeRef` errors on freshly planned
+entities are expected — they list the behavior the implementation still has
+to evidence (see [How BusinessLens works](./guide.md)).
 
 JSON output is:
 
@@ -135,6 +125,8 @@ Building pins provenance to the current commit and refuses to run when:
 
 - the tracked worktree has uncommitted changes;
 - `.businesslens/` contains untracked or modified files;
+- `coverage.md` has `status: draft` — a planned map has no evidence to
+  publish; verify the implementation and move coverage off draft first;
 - `HEAD` is detached instead of on a named branch;
 - `origin` does not normalize to a credential-free HTTPS URL.
 

--- a/docs/format.md
+++ b/docs/format.md
@@ -1,17 +1,31 @@
 ---
-title: The .businesslens/ format
+title: Format contract
 description: The contract for the git-tracked product map — folder layout, universal conventions, entities, and codeRefs.
-order: 3
+section: open-source
+group: Reference
+order: 20
 ---
 
 # The `.businesslens/` Format
 
 This document is the contract for the BusinessLens PDD folder: the git-tracked
 product map that lives inside a repository. Everything the public CLI validates
-is defined here. The map is **descriptive product truth** — what the product
-does today, for whom, with code evidence. Prescriptive change intent (what will
-be built next) belongs to your SDD tool of choice and is deliberately out of
-scope.
+is defined here. The map is **evidence-backed product truth**: every
+behavioral claim (journeys and scenarios) must cite tracked code, and a green
+`validate` means the map and the code agree.
+
+Planning uses the same file: describe intended behavior by editing the map on
+a branch. Until the implementation lands and evidence is attached, `validate`
+reports new, unevidenced journeys and scenarios as missing `codeRefs`.
+`businesslens-verify` derives the complete worklist from the map diff too, so
+changed higher-level contracts and deleted behavior are not invisible merely
+because they need no new evidence field. Git is the change model: branches
+hold plans, pull requests review them, history archives them. The one
+exception is a brand-new product with no code at all, where
+`coverage.md` `status: draft` marks the whole map as planned (see
+[coverage](#coveragemd)). The technical *how* of a change (specs, designs,
+task lists) still belongs to your SDD tool of choice and is referenced via
+`links`.
 
 ## Folder layout
 
@@ -66,6 +80,11 @@ codeRef must point at a tracked file. `codeRefs` are accepted and preserved on
 every entity. Journeys and scenarios require at least one because they make
 behavioral claims; actors, experiences, and domains may carry evidence when
 their boundary is directly represented in code.
+
+While `coverage.md` has `status: draft` (a planned, not-yet-implemented
+map), a journey or scenario without `codeRefs` is a **warning** instead of
+an error. A codeRef that is present must always point at a tracked file —
+planned behavior carries no evidence rather than invented evidence.
 
 ## links (the PDD → SDD bridge)
 
@@ -253,6 +272,13 @@ repository evidence. Entity and file counts in the portable output are
 computed by `build` from the model and the tracked file list — they are never
 authored. The validator checks the authored entities and relationships; it
 does not compile or publish the map.
+
+`status: draft` marks a **planned map**: a greenfield product authored
+before any implementation exists. While draft, missing journey and scenario
+`codeRefs` validate as warnings instead of errors, and `build`/`publish`
+refuse the map — an unimplemented product has no evidence to show. Once the
+implementation is verified and evidence is attached, set the status to
+`partial` or `complete`; from then on evidence is strictly required.
 
 ## Generated files
 

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -1,0 +1,89 @@
+---
+title: How it works
+description: The framework guide — one artifact, git as the change model, and which skill to use when.
+section: open-source
+group: Concepts
+order: 4
+---
+
+# How BusinessLens works
+
+BusinessLens keeps exactly one artifact: the product map. Everything else is
+a workflow around it.
+
+## The map and its rule
+
+The map describes the product — actors, experiences, domains, journeys,
+scenarios. Its one rule: **behavioral claims need evidence.** Every journey
+and scenario must cite tracked code (`codeRefs`), and `validate` checks
+every path against `git ls-files`. On your default branch the map is always
+green: evidence-backed truth.
+
+## Git is the change model
+
+Planning does not need its own folder, lifecycle, or status fields — git
+already has all three:
+
+- **A plan is a branch** where the map describes intended behavior. New
+  journeys and scenarios have no `codeRefs` yet, so `validate` lists them as
+  errors — the evidence checklist, not a problem to suppress. The map diff
+  remains the complete plan, including changed and deleted entities.
+- **Review is the pull request.** The map diff shows the product delta;
+  reviewers approve behavior before or alongside code.
+- **Done is verification complete and validation green.**
+  `businesslens-verify` checks every planned addition, change, and removal;
+  scenario Trigger, Steps, and Outcome are the behavioral acceptance
+  contract. It attaches evidence to what exists and reports every verdict.
+- **The archive is git history.**
+
+The one special state is a brand-new product with no code at all:
+`coverage.md` `status: draft` marks the whole map as planned, downgrading
+missing evidence to warnings so the draft validates green. `build` and
+`publish` refuse draft maps; a fully successful verify moves coverage off
+draft, and evidence is strictly required from then on.
+
+## The loop
+
+```text
+map exists?  no + code    → /businesslens-init      (evidence-backed map)
+             no + blank   → /businesslens-plan      (guided interview → draft map)
+
+every feature:
+  /businesslens-plan …    edit the map to the intended behavior
+  implement               your coding agent + your SDD tool
+  /businesslens-verify    evidence attached, gaps reported
+  validate green          merge; CI gates the PR
+
+map drifted (unplanned change)? → /businesslens-sync
+```
+
+## Which skill, when
+
+| Situation | Skill |
+| --- | --- |
+| Existing code, no map yet | `businesslens-init` |
+| Blank repository, new product | `businesslens-plan` |
+| New feature or product decision, before code | `businesslens-plan` (quick or thorough) |
+| A design deliverable nobody will implement yet | `businesslens-plan` (the draft map is the deliverable) |
+| Planned behavior implemented, needs checking | `businesslens-verify` |
+| Code changed without a plan | `businesslens-sync` |
+| One journey or experience needs exhaustive depth | `businesslens-deep-dive` |
+| Deterministic check, CI readiness | `businesslens-validate` |
+| Something looks wrong, stale, or stuck | `businesslens-doctor` |
+| Publish a snapshot to the platform | `businesslens-publish` |
+
+## Scenarios are the acceptance criteria
+
+There is no separate acceptance-criteria artifact: a scenario's Trigger,
+ordered Steps, and Outcome are already an observable, checkable contract.
+Write them so a reviewer could check them against source code without
+executing anything — "submitting an empty cart shows an error and keeps the
+cart", not "cart validation works". `businesslens-verify` verifies exactly
+that, statically, and never marks a scenario met without direct evidence.
+
+## Where publishing fits
+
+`build` compiles the map into a portable document; `publish` submits it as a
+commit-pinned snapshot. Both run from CI on the default branch (see
+[Validate in CI](./ci.md)) and both refuse draft maps — nothing
+unimplemented ever publishes.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,6 +1,6 @@
 ---
 title: Introduction
-description: BusinessLens is Product-Driven Design for coding agents — a git-tracked product map with code evidence, where planning is editing the map and validation green means done.
+description: BusinessLens is Product-Driven Development for coding agents — a git-tracked product map with code evidence, where planning is editing the map and validation green means done.
 section: open-source
 group: Get started
 order: 1
@@ -8,7 +8,7 @@ order: 1
 
 # Introduction
 
-**BusinessLens is Product-Driven Design (PDD) for coding agents.** It keeps
+**BusinessLens is Product-Driven Development (PDD) for coding agents.** It keeps
 one artifact: a git-tracked product map in `.businesslens/` — who the
 product serves, what they accomplish, and where the code proves it.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,17 +1,19 @@
 ---
 title: Introduction
-description: BusinessLens is Product-Driven Design for coding agents — a git-tracked product map in .businesslens/ with code evidence.
+description: BusinessLens is Product-Driven Design for coding agents — a git-tracked product map with code evidence, where planning is editing the map and validation green means done.
+section: open-source
+group: Get started
 order: 1
 ---
 
 # Introduction
 
-**BusinessLens is Product-Driven Design (PDD) for coding agents.** It builds a
-git-tracked product map in `.businesslens/`: who the product serves, what they
-accomplish, and where the code proves it.
+**BusinessLens is Product-Driven Design (PDD) for coding agents.** It keeps
+one artifact: a git-tracked product map in `.businesslens/` — who the
+product serves, what they accomplish, and where the code proves it.
 
-The map is Markdown, reviewable in pull requests, and useful without a hosted
-service.
+The map is Markdown, reviewable in pull requests, and useful without a
+hosted service.
 
 ```text
 .businesslens/
@@ -24,23 +26,43 @@ service.
 └── coverage.md
 ```
 
-## Why a product map
+## One artifact, one rule
 
-- Agents read the map before building, so work starts from product context
-  instead of repository archaeology.
-- Every claim carries `codeRefs` — evidence validated against `git ls-files`,
-  so the map cannot silently drift into fiction.
-- The map records what **is**. Prescriptive change intent (what will be built
-  next) belongs to your SDD tool of choice — see
-  [PDD ♥ SDD](./pdd-and-sdd.md).
+Every behavioral claim (journeys and scenarios) must cite tracked code —
+`codeRefs` validated against `git ls-files`. A green `validate` means the
+map and the code agree.
+
+That one rule makes planning simple: **plan by editing the map.** Describe
+the intended behavior on your branch; `validate` lists new journeys and
+scenarios that still lack evidence. Implement, then `businesslens-verify`
+checks every planned addition, change, and removal from the complete map diff
+and attaches evidence to implemented behavior. Verification complete plus
+validation green means done. Git is the change model: branches hold plans,
+pull requests review them, history archives them.
+
+## Two ways in, one loop after
+
+- **Existing product** — `/businesslens-init` inspects the code and builds
+  the evidence-backed map.
+- **Blank repository** — `/businesslens-plan` interviews you and authors the
+  whole product as a draft map (evidence relaxed until the code exists).
+
+Then, for every feature:
+
+```text
+/businesslens-plan   →   implement   →   /businesslens-verify   →   green
+```
+
+Code changed without a plan? `/businesslens-sync` repairs the map.
 
 ## The pieces
 
 | Piece | What it does |
 | --- | --- |
 | `businesslens` CLI | Installs the skills and validates the map deterministically — [CLI reference](./cli.md) |
-| Agent skills | Build and maintain the map inside your AI harness — [Skills reference](./skills.md) |
+| Agent skills | Plan, build, verify, and maintain the map inside your AI harness — [Skills reference](./skills.md) |
 | `.businesslens/` | The durable, git-tracked product map — [format contract](./format.md) |
-| Platform (optional) | Hosts published commit-pinned snapshots for topology, release changes, and comparison |
+| Platform (optional) | Hosts published commit-pinned snapshots for topology, release changes, and comparison — covered in the **Platform** section of the docs |
 
-Start with the [Quickstart](./quickstart.md).
+Start with the [Quickstart](./quickstart.md), then read
+[How BusinessLens works](./guide.md).

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -1,0 +1,74 @@
+---
+title: Installation
+description: Install the BusinessLens skills into your AI harnesses — providers, scopes, non-interactive setup, and updating.
+section: open-source
+group: Get started
+order: 2
+---
+
+# Installation
+
+BusinessLens is installed once per repository (or once per machine) with the
+`businesslens` CLI. It requires Node.js 20.12 or newer.
+
+```bash
+npx businesslens@latest install
+```
+
+The installer detects supported AI harnesses, lets you customize the
+selection, asks for project or global scope, and installs only the
+BusinessLens skills. It never creates `.businesslens/`, alters `AGENTS.md`,
+installs hooks, connects to the platform, or publishes data — building the
+map belongs to the skills themselves.
+
+## Supported harnesses
+
+| Provider | Project skills directory |
+| --- | --- |
+| Claude Code | `.claude/skills/` |
+| Codex | `.agents/skills/` |
+| Cursor | `.cursor/skills/` |
+| Gemini CLI | `.gemini/skills/` |
+| GitHub Copilot | `.github/skills/` |
+
+Global installs respect `CLAUDE_CONFIG_DIR` and `CODEX_HOME`; other
+providers use their standard user directories.
+
+## Project or global scope
+
+- **Project** installs into the repository, so the skills travel with it and
+  teammates get them on checkout.
+- **Global** installs into your user directory, making the skills available
+  in every repository you open.
+
+## Non-interactive setup
+
+```bash
+npx businesslens@latest install \
+  --providers claude,codex \
+  --scope project \
+  --yes
+```
+
+`--yes` accepts detected providers and defaults to project scope. `--force`
+replaces an unmarked colliding `businesslens-*` directory — without it, the
+installer refuses to overwrite skills it does not own.
+
+## Updating
+
+```bash
+npx businesslens@latest update
+```
+
+Update discovers BusinessLens-managed installations through their ownership
+markers and refreshes only those skill directories. It never touches
+`.businesslens/` or `AGENTS.md`. Narrow it with `--scope project|global` or
+`--providers <list>`.
+
+## Claude Code plugin
+
+Claude Code users may alternatively install from this repository's
+marketplace manifest. The standalone CLI remains the primary installation
+experience.
+
+Next: the [Quickstart](./quickstart.md).

--- a/docs/pdd-and-sdd.md
+++ b/docs/pdd-and-sdd.md
@@ -1,21 +1,28 @@
 ---
 title: PDD ♥ SDD
 description: How Product-Driven Design coexists with spec-driven development frameworks like OpenSpec and spec-kit.
-order: 7
+section: open-source
+group: Concepts
+order: 6
 ---
 
 # PDD ♥ SDD
 
-BusinessLens deliberately does not compete with spec-driven development
-frameworks. The borderline:
+BusinessLens owns the **product level**: what the product does, for whom,
+and — when you plan by editing the map on a branch — what it will do next.
+Spec-driven development frameworks own the **technical level**: how a change
+is designed, built, and broken into tasks. The borderline:
 
 | | PDD (BusinessLens) | SDD (OpenSpec, spec-kit, freestyle) |
 | --- | --- | --- |
-| Answers | What IS the product, for whom, where is the proof | What WILL change, how it is built and verified |
-| Tense | Present, descriptive | Future, prescriptive |
+| Answers | What the product does (and, on a branch, what it will do), for whom, where is the proof | How a change is designed, built, and verified technically |
+| Altitude | Product: actors, journeys, observable scenarios | Technical: specs, designs, task lists |
 | Lifetime | Durable — the map lives as long as the product | Transient — proposals land and get archived |
-| Artifact | `.businesslens/` product map with codeRefs | Specs, proposals, designs, task lists |
-| Owner of change workflow | Never | Always |
+| Change model | Git: branches plan, PRs review, `validate` green = done | Its own change/proposal folders |
+
+On the default branch the map is always descriptive, evidence-backed truth.
+On a working branch it may briefly claim more than the code delivers — that
+gap is exactly what `businesslens-verify` closes before merge.
 
 ## How they link
 
@@ -24,10 +31,11 @@ frameworks. The borderline:
   X" becomes a reviewable claim.
 - **PDD → SDD**: map entities point at specs and design docs with `links:`
   (`rel: spec|proposal|doc|adr`). The map never copies spec content.
-- **The loop**: agents read the map before building (product context), build
-  against the SDD change (intent), and update the map after the change lands
-  (the `businesslens-sync` skill). An archived SDD change is the strongest
-  signal that map entities need updating.
+- **The loop**: plan the product delta by updating the map
+  (`businesslens-plan`), design and implement against your SDD change, then
+  `businesslens-verify` checks the code delivers the planned behavior and
+  attaches evidence. An archived SDD change with no matching map update is
+  the strongest drift signal (`businesslens-sync`).
 
 The `businesslens-init` skill detects SDD roots (`openspec/`, `specs/`,
 `.kiro/`), records them in `.businesslens/config.yaml`, and includes the

--- a/docs/pdd-and-sdd.md
+++ b/docs/pdd-and-sdd.md
@@ -1,6 +1,6 @@
 ---
 title: PDD ♥ SDD
-description: How Product-Driven Design coexists with spec-driven development frameworks like OpenSpec and spec-kit.
+description: How Product-Driven Development coexists with spec-driven development frameworks like OpenSpec and spec-kit.
 section: open-source
 group: Concepts
 order: 6

--- a/docs/product-map.md
+++ b/docs/product-map.md
@@ -1,0 +1,97 @@
+---
+title: The product map
+description: What actors, experiences, domains, journeys, and scenarios are — the entity model behind .businesslens/, in plain language.
+section: open-source
+group: Concepts
+order: 5
+---
+
+# The product map
+
+The map answers one question from five angles: *what does this product do,
+for whom, and where does the code prove it?* Each entity type covers one
+angle. This page explains how to think about them; the exact file shapes
+live in the [format contract](./format.md).
+
+## Actors — who
+
+An actor is someone (or something) with a goal or a privilege: a shopper, a
+store admin, a billing webhook. Actors are defined by what they are trying
+to accomplish, never by UI screens or database roles. If two "roles" share
+the same goals and permissions, they are one actor.
+
+## Experiences — where
+
+An experience is a surface of the product with a stable audience and a
+capability boundary: the public storefront, the admin console, a CLI, an
+API for partners. Each declares who uses it (`actors`), how it is reached
+(`entryPoints`), what protects it (`access`), what a successful visit ends
+with (`exit`), and — most importantly — its **capability boundary**: what
+this surface can and cannot do.
+
+## Domains — which area
+
+Domains group journeys into recognizable product areas — ordering, catalog,
+billing. They are an organizing layer for navigation and topology, not a
+technical decomposition; name them the way your product people talk.
+
+## Journeys — what users accomplish
+
+A journey is a stable user or operator goal: *browse and buy*, *refund an
+order*, *rotate an API key*. It belongs to a domain, is performed by actors
+through experiences, and carries `codeRefs` proving the goal is really
+served by the code. Journeys are the map's backbone — if a goal disappears
+from the product, its journey is deleted, not archived.
+
+## Scenarios — how it observably plays out
+
+Each journey has one or more scenarios: concrete, observable paths through
+the goal. A scenario has a `kind` (from your `taxonomies.yaml` — primary,
+edge, and whatever vocabulary fits), and three structured sections:
+
+- **Trigger** — what starts it ("the shopper presses *Place order* with a
+  non-empty cart");
+- **Steps** — the ordered observable progression;
+- **Outcome** — what the user or operator ends up with.
+
+Scenarios are deliberately the smallest unit that can be *verified*: their
+Trigger/Steps/Outcome are the acceptance contract that
+[`businesslens-verify`](./skill-businesslens-verify.md) checks against the
+implementation. Scenario IDs are globally unique across the map, so any
+scenario can be referenced unambiguously.
+
+## Evidence — where the code proves it
+
+Every journey and scenario cites tracked code with compact `codeRefs`
+(`src/services/orders.ts#OrderService.submit`). The validator checks every
+path against `git ls-files`, which is what keeps the map from drifting into
+fiction. A claim without evidence is, by definition, unfinished work — see
+[How it works](./guide.md) for how that powers planning.
+
+## Coverage — how honest the map is
+
+`coverage.md` records how the map was built and what it deliberately leaves
+out: the method, inspected source areas, unmapped surfaces, and known
+limitations. Its `status` (`draft | partial | complete`) is about the map's
+completeness, with one special meaning: `draft` marks a planned greenfield
+map whose evidence hasn't been earned yet.
+
+## A worked example
+
+```text
+.businesslens/
+├── product.md                       # Fixture Shop
+├── actors/shopper.md                #   who: buys products
+├── actors/store-admin.md            #   who: manages orders
+├── domains/catalog.md               #   area: finding products
+├── domains/ordering.md              #   area: buying and refunds
+├── experiences/storefront.md        #   where: public web store
+├── experiences/admin-console.md     #   where: restricted admin area
+└── journeys/browse-and-buy/         #   goal: find a product and buy it
+    ├── journey.md                   #     domain: ordering, actor: shopper
+    └── scenarios/complete-checkout.md   # observable path, with codeRefs
+```
+
+Reading order for a newcomer: `product.md` → experiences (the surfaces) →
+journeys per domain (the goals) → scenarios (the behavior). That is also
+exactly the order an agent reads before touching your code.

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -1,47 +1,45 @@
 ---
 title: Quickstart
-description: Install the skills, build the map in your AI harness, review, and commit.
-order: 2
+description: Install the skills, pick your entry — map existing code or plan a new product — then run the plan → implement → verify loop.
+section: open-source
+group: Get started
+order: 3
 ---
 
 # Quickstart
 
-Requires Node.js 20.12 or newer.
-
 ## 1. Install the skills
 
-Run this in the repository you want to map:
+Run this in the repository (Node.js 20.12+):
 
 ```bash
 npx businesslens@latest install
 ```
 
-The installer detects supported AI harnesses (Claude Code, Codex, Cursor,
-Gemini CLI, GitHub Copilot), lets you customize the selection, asks for
-project or global scope, and installs only the BusinessLens skills.
+The installer detects your AI harnesses and installs only the BusinessLens
+skills — providers, scopes, and non-interactive setup are covered in
+[Installation](./installation.md).
 
-Non-interactive setup:
+## 2. Get a map
 
-```bash
-npx businesslens@latest install \
-  --providers claude,codex \
-  --scope project \
-  --yes
-```
-
-## 2. Build the map
-
-Invoke the initialization skill in your AI harness:
+**Existing product** — build it from the code:
 
 ```text
 /businesslens-init
 ```
 
-Codex users invoke the same skill as `$businesslens-init`. The skill inspects
-the repository without executing its code, authors the full map, installs the
-managed `AGENTS.md` guidance, and validates the result.
+(Codex users invoke skills as `$businesslens-init`.)
 
-## 3. Review and commit
+**Blank repository** — plan the product first:
+
+```text
+/businesslens-plan
+```
+
+The skill interviews you and authors the whole product as a draft map — no
+code, no evidence yet, validation green with warnings.
+
+Either way, review the diff like any pull request, then:
 
 ```bash
 npx businesslens@latest validate
@@ -49,23 +47,30 @@ git add .businesslens AGENTS.md
 git commit -m "docs: add BusinessLens product map"
 ```
 
-Review the map like any other change: the entities are Markdown, and every
-claim carries `codeRefs` your reviewers can open.
-
-## 4. Keep it current
-
-After behavior changes, invoke `businesslens-sync` in your harness, then
-validate. Add the deterministic validator to every pull request —
-see [Validate in CI](./ci.md).
-
-## Optional: publish to the platform
+## 3. The loop for every feature
 
 ```text
-/businesslens-publish
+/businesslens-plan add guest checkout     # map describes intended behavior
+… implement with your coding agent …
+/businesslens-verify                      # evidence attached, gaps reported
+npx businesslens@latest validate          # green = done
 ```
 
-Publishing submits a snapshot pinned to the current commit for topology,
-release changes, and snapshot comparison. The map is fully useful without it —
-see the [CLI reference](./cli.md) for `build` and `publish` details. The skill
-checks for `BUSINESSLENS_API_KEY` and runs the CLI outside the target
-repository so local npm configuration and binaries cannot receive the key.
+`validate` failing in between is not a problem: its missing-evidence errors
+identify new journeys and scenarios that still need proof. The verifier also
+checks changed and deleted work from the complete map diff.
+
+## 4. Keep it honest
+
+- Gate every pull request with the validator — see [Validate in CI](./ci.md).
+- If code changed without a plan, repair the map with `/businesslens-sync` —
+  see [Recover from drift](./tutorial-recover-from-drift.md).
+
+## Optional: the platform
+
+The map is fully useful on its own. When you want hosted topology, release
+changes, and snapshot comparison across your workspace, publish
+commit-pinned snapshots with `/businesslens-publish` — setup, snapshots,
+and workspaces are covered in the **Platform** section of the docs. The
+`build` and `publish` commands themselves are in the
+[CLI reference](./cli.md).

--- a/docs/skill-businesslens-deep-dive.md
+++ b/docs/skill-businesslens-deep-dive.md
@@ -1,0 +1,58 @@
+---
+title: deep-dive
+description: Expand one journey or experience to exhaustive, evidence-backed fidelity.
+section: open-source
+group: Skills
+order: 16
+---
+
+# businesslens-deep-dive
+
+Takes one named journey or experience to exhaustive fidelity by mining its
+implementation and tests for scenarios, boundaries, and edge cases — depth
+without remapping the repository.
+
+## When to use it
+
+- A high-value journey needs its full scenario space mapped, not just the
+  primary path.
+- An experience's audience, access, entry points, or capability boundary
+  should be verified against the actual guards and handlers.
+
+## Invocation
+
+```text
+/businesslens-deep-dive browse-and-buy
+/businesslens-deep-dive the storefront experience
+```
+
+A target ID is required; the skill asks for one if the invocation does not
+identify it.
+
+## What it reads and writes
+
+Reads the target's relations, scenarios, links, and `codeRefs`, then
+follows the evidence into entry points, implementation, adjacent services,
+persistence, configuration, and tests. Writes new or tightened scenarios
+under the target journey, corrected experience boundaries, stronger
+`path#symbol` evidence, and a `coverage.md` update when the mapped surface
+materially changed.
+
+## How it works
+
+For a journey it enumerates the evidenced scenario space — primary success,
+permission and authentication failure, validation and malformed input,
+conflict and idempotency, dependency timeout and external failure, recovery
+and retry — and adds only materially distinct scenarios, each with a
+globally unique ID, concrete Trigger/Steps/Outcome, and direct evidence.
+For an experience it reconciles the declared boundary with what the code
+actually guards, and every journey exposed through it. It validates until
+green and reports unresolved limitations honestly.
+
+## Guardrails
+
+- Stays inside the selected target except for required relation repairs.
+- Never inflates scenario counts with implementation detail invisible to
+  the user or operator.
+- Treats ambiguous behavior as a limitation, not a fact.
+- Never executes target code, never contacts the platform.

--- a/docs/skill-businesslens-doctor.md
+++ b/docs/skill-businesslens-doctor.md
@@ -1,0 +1,56 @@
+---
+title: doctor
+description: Investigate installation and map health — diagnose by default, repair only on explicit request.
+section: open-source
+group: Skills
+order: 18
+---
+
+# businesslens-doctor
+
+Root-cause analysis for a map that fails validation, looks stale, or just
+feels wrong. Doctor diagnoses by default and never mutates anything unless
+you explicitly ask for repairs.
+
+## When to use it
+
+- A simple validation report is not enough — findings need investigation.
+- The map may have drifted semantically even though validation is green.
+- You want a health report before a release or a publish.
+
+## Invocation
+
+```text
+/businesslens-doctor
+/businesslens-doctor and repair what you find
+```
+
+## What it checks
+
+- Validator output, parsed in full.
+- Missing files, unresolved relations, `codeRefs` no longer in
+  `git ls-files`, journeys without scenarios or experiences.
+- Evidence-less entities sitting on the default branch, or `coverage.md`
+  stuck in `draft` after implementation shipped — planned work that never
+  went through [`businesslens-verify`](./skill-businesslens-verify.md).
+- Placeholder prose, unsupported certainty, weak coverage claims, generated
+  `cache/` content accidentally tracked.
+- Exactly one well-formed `<!-- businesslens:begin/end -->` managed block in
+  the root `AGENTS.md`.
+- Recent diffs and commits for likely drift — reported as likely, never as
+  proven.
+
+## What it reports
+
+Findings classified as **blocking** (validator cannot accept the map),
+**drift** (authored truth likely no longer matches the implementation),
+**coverage** (material surfaces unmapped), or **hygiene** (generated files,
+duplicated markers, weak evidence) — with the exact files involved and an
+ordered repair plan. On explicit request it makes the smallest targeted
+repairs and re-validates until green.
+
+## Guardrails
+
+- Never mutates the map during a diagnostic-only request.
+- Never treats a green structural validator as proof of complete coverage.
+- Never executes target code, never contacts the platform.

--- a/docs/skill-businesslens-init.md
+++ b/docs/skill-businesslens-init.md
@@ -1,0 +1,60 @@
+---
+title: init
+description: Build the initial evidence-backed product map by inspecting an existing codebase.
+section: open-source
+group: Skills
+order: 12
+---
+
+# businesslens-init
+
+Builds the repository's durable description of what the product does today:
+inspects the codebase statically, authors the complete `.businesslens/` map
+with `codeRefs` on every behavioral claim, installs the managed `AGENTS.md`
+guidance block, and validates until green.
+
+## When to use it
+
+- Adopting BusinessLens in a repository that already has code.
+- Replacing an incomplete scaffold or rebuilding the map from scratch.
+- Not for blank repositories — a new product is planned as a draft map with
+  [`businesslens-plan`](./skill-businesslens-plan.md), and init will route
+  you there.
+
+## Invocation
+
+```text
+/businesslens-init
+```
+
+Codex users invoke skills as `$businesslens-init`.
+
+## What it reads and writes
+
+Reads repository instructions (`AGENTS.md`, `CLAUDE.md`, READMEs), docs,
+detected SDD roots (`openspec/`, `specs/`, `.kiro/`), and the high-signal
+files surfaced by its bundled inventory script. Writes the whole authored
+`.businesslens/` tree — `config.yaml`, `taxonomies.yaml`, `product.md`,
+`coverage.md`, all entity files — plus the managed
+`<!-- businesslens:begin/end -->` block in the root `AGENTS.md`.
+
+## How it works
+
+It forms repository-backed hypotheses for actors, experiences, domains, and
+journeys, then traces behavior from entry points through handlers, services,
+persistence, integrations, configuration, and tests. Scenarios cover
+primary, permission, validation, conflict, and external-failure paths when
+the code evidences them. It asks you only about ambiguity the repository
+cannot resolve, finishes `coverage.md` honestly, and runs
+`npx businesslens validate --json` until green.
+
+## Guardrails
+
+- Describes evidenced behavior, never desired behavior; no guarantees
+  inferred from names.
+- Never executes the repository's application, build, migrations, or tests.
+- Never overwrites a mature existing map without explicit approval (that is
+  [`businesslens-sync`](./skill-businesslens-sync.md)'s job).
+- Never contacts the platform.
+
+Tutorial: [Map existing code](./tutorial-map-existing-product.md).

--- a/docs/skill-businesslens-plan.md
+++ b/docs/skill-businesslens-plan.md
@@ -1,0 +1,69 @@
+---
+title: plan
+description: Plan a product or feature directly in the map before implementation — guided greenfield definition or quick/thorough feature planning.
+section: open-source
+group: Skills
+order: 13
+---
+
+# businesslens-plan
+
+Plans product behavior by editing the map itself: describe the intended
+actors, journeys, and scenarios before (or instead of) writing code. Git is
+the change model — the branch holds the plan, and validation's
+`needs at least one codeRef` findings on the planned entities are the
+evidence checklist for new journeys and scenarios. The map diff remains the
+complete plan, including changes and removals.
+
+## When to use it
+
+- A **blank repository**: it runs the full guided product interview and
+  authors the whole product as a draft map (`coverage: draft`).
+- A **mapped repository**: it edits the map on your branch to the intended
+  state for a new feature.
+- A **design deliverable**: a draft map nobody implements yet is a
+  validated, portable product spec.
+- A repository with code but no map gets routed to
+  [`businesslens-init`](./skill-businesslens-init.md) first — it never
+  plans against unmapped code.
+
+## Invocation
+
+```text
+/businesslens-plan add guest checkout to the storefront
+/businesslens-plan quick: add dark mode
+/businesslens-plan thorough: rethink the onboarding flow
+```
+
+`quick` asks at most a few batched questions and drafts the rest from map
+context; `thorough` runs the full interview (why, who, surfaces, journeys,
+scenario space, removals, done-when). Without a keyword it infers the depth
+from the ask.
+
+## What it reads and writes
+
+Reads the existing map and repository material. Writes map entity files to
+their desired state (new files carry **no** codeRefs — planned behavior has
+no evidence yet), new scenario kinds in `taxonomies.yaml`, and on
+greenfield the minimal scaffold (`config.yaml`, `taxonomies.yaml`,
+`product.md`, `coverage.md` at `status: draft`, `.gitignore`).
+
+## How it works
+
+Interview → author → validate. It proposes concrete drafts you correct
+rather than interrogating from a blank page, keeps prose at product
+altitude, and ends with only expected missing-evidence findings on newly
+unevidenced journeys and scenarios. Implement, then run
+[`businesslens-verify`](./skill-businesslens-verify.md).
+
+## Guardrails
+
+- Never invents implementation detail — no stacks, endpoints, schemas, or
+  file names in entity prose.
+- Never adds a codeRef for behavior that does not exist.
+- Never weakens evidenced current truth except where the plan deliberately
+  retires it.
+- Never implements, executes target code, or contacts the platform.
+
+Tutorials: [Plan a new product](./tutorial-plan-new-product.md) ·
+[Ship a feature](./tutorial-ship-a-feature.md).

--- a/docs/skill-businesslens-publish.md
+++ b/docs/skill-businesslens-publish.md
@@ -1,0 +1,54 @@
+---
+title: publish
+description: Publish the map to the platform as a commit-pinned snapshot — only ever on explicit request.
+section: open-source
+group: Skills
+order: 19
+---
+
+# businesslens-publish
+
+Compiles `.businesslens/` into a portable snapshot pinned to the current
+commit and submits it to the BusinessLens platform. It is the only skill
+that contacts the platform, and it never runs without explicit intent — the
+map is fully useful in the repository without publishing.
+
+## When to use it
+
+- You explicitly want the map on the platform for topology, release
+  changes, and snapshot comparison (see the Platform docs section).
+- For automatic publishing on merge, use the CI recipe in
+  [Validate in CI](./ci.md) instead of running this by hand.
+
+## Invocation
+
+```text
+/businesslens-publish
+```
+
+Requires a workspace API key exported as `BUSINESSLENS_API_KEY` (created on
+the platform under Workspace Settings → API keys). The skill checks only
+that the key is *present* — it never asks for, prints, or logs its value.
+
+## How it works
+
+A strict preflight runs first: the map exists and validates green, the
+tracked worktree is clean, `.businesslens/` is fully committed, `HEAD` is on
+a named branch, and `origin` normalizes to a credential-free HTTPS URL.
+Publishing then runs through a bundled isolated runner that installs the
+CLI in a temporary directory — so a target-local binary or `.npmrc` can
+never intercept the key — and reports the returned snapshot URL. An
+interrupted publish resumes from `.businesslens/cache/analysis.json`;
+re-publishing the same commit replaces that commit's snapshot.
+
+Draft maps (`coverage: draft`) refuse to build or publish — an
+unimplemented product has no evidence to show.
+
+## Guardrails
+
+- Never prints, echoes, logs, or writes `BUSINESSLENS_API_KEY` anywhere.
+- Never publishes as a side effect of another workflow, and never edits map
+  files to force validation green.
+- The only writes in the target repository are the CLI's own gitignored
+  `build/` and `cache/` outputs.
+- Never executes target code.

--- a/docs/skill-businesslens-sync.md
+++ b/docs/skill-businesslens-sync.md
@@ -1,0 +1,56 @@
+---
+title: sync
+description: Repair the map after code changed without a plan — targeted drift recovery, not the routine loop.
+section: open-source
+group: Skills
+order: 15
+---
+
+# businesslens-sync
+
+Recovers map truth after **unplanned** code changes — a hotfix, a refactor
+that moved evidence, a feature that skipped planning. The primary loop is
+plan → implement → verify; sync is the repair lane for everything that
+bypassed it, and it updates only the product truth the changes actually
+affected.
+
+## When to use it
+
+- The map drifted: `validate` reports stale `codeRefs`, or the code does
+  something the map does not say.
+- After merging work that never went through
+  [`businesslens-plan`](./skill-businesslens-plan.md).
+- Not after planned work — run
+  [`businesslens-verify`](./skill-businesslens-verify.md) there instead.
+
+## Invocation
+
+```text
+/businesslens-sync
+/businesslens-sync for the changes in the last three commits
+```
+
+## What it reads and writes
+
+Reads the change range — explicit user context first, otherwise the working
+tree, staged diff, and recent commits — and the affected implementation.
+Writes only affected entities: revised journey and scenario prose and
+evidence, the smallest justified new entities, deleted obsolete ones,
+repaired `codeRefs`, and `coverage.md` when the inspected surface
+materially changed.
+
+## How it works
+
+It establishes a validation baseline (pre-existing errors are reported, not
+concealed), maps changed files to existing entity `codeRefs`, inspects new
+surfaces that may expose unreferenced behavior, applies the smallest
+targeted updates, checks reverse relationships after every structural edit,
+and validates until green.
+
+## Guardrails
+
+- Never rewrites the whole map when a targeted update suffices.
+- Never copies prescriptive SDD text into the descriptive map.
+- Never executes target code, never contacts the platform.
+
+Tutorial: [Recover from drift](./tutorial-recover-from-drift.md).

--- a/docs/skill-businesslens-validate.md
+++ b/docs/skill-businesslens-validate.md
@@ -1,0 +1,48 @@
+---
+title: validate
+description: Run the deterministic validator and explain every error, warning, and count — strictly read-only.
+section: open-source
+group: Skills
+order: 17
+---
+
+# businesslens-validate
+
+The read-only agent interface to the deterministic CLI validator: it runs
+`npx businesslens validate --json`, treats the CLI as the authority, and
+explains every finding without changing a single file.
+
+## When to use it
+
+- Checking a map after authoring, syncing, or planning.
+- Confirming CI readiness before opening a pull request.
+- Understanding what a specific finding means — it reads the referenced
+  files for context and points at the fix.
+- For repairs or drift investigation, use
+  [`businesslens-doctor`](./skill-businesslens-doctor.md) instead.
+
+## Invocation
+
+```text
+/businesslens-validate
+```
+
+## What it reports
+
+- **Result** — pass or fail, with the exit status.
+- **Errors and warnings** — every finding, grouped by file, explained
+  against the [validation rules](./validation-rules.md).
+- **Counts** — actors, experiences, domains, journeys, scenarios.
+- **Next action** — `businesslens-init` for a missing map,
+  `businesslens-verify` when `needs at least one codeRef` findings mean
+  planned-but-unverified behavior, `businesslens-doctor` when diagnosis or
+  repair is needed.
+
+It states explicitly that a green result proves format and relationship
+integrity — not complete or current product coverage.
+
+## Guardrails
+
+- Strictly read-only, even when validation fails.
+- Never suppresses, rewrites, or reinterprets validator findings.
+- Never executes target code, never contacts the platform.

--- a/docs/skill-businesslens-verify.md
+++ b/docs/skill-businesslens-verify.md
@@ -1,0 +1,66 @@
+---
+title: verify
+description: Statically verify the implementation delivers the planned map changes — evidence attached, gaps reported honestly.
+section: open-source
+group: Skills
+order: 14
+---
+
+# businesslens-verify
+
+Closes the gap between what the map claims and what the code proves. It
+derives the planned delta fresh on every run — the map diff against your
+merge base, plus every journey and scenario still lacking `codeRefs` — so
+the plan can keep evolving while you implement.
+
+## When to use it
+
+- After implementing behavior that was planned in the map with
+  [`businesslens-plan`](./skill-businesslens-plan.md), before merging.
+- To finish a greenfield draft map: a fully verified product moves
+  `coverage.md` off `draft`.
+- Not for unplanned drift — that is
+  [`businesslens-sync`](./skill-businesslens-sync.md)'s direction.
+
+## Invocation
+
+```text
+/businesslens-verify
+/businesslens-verify against origin/main
+```
+
+Without a base it uses the merge base with the default branch; with no base
+at all (fresh greenfield repo) it treats the whole map as planned.
+
+## What it reads and writes
+
+Reads the map diff and the implementation. Writes only map files:
+`codeRefs` on met scenarios and journeys (preferring `path#symbol`),
+user-confirmed prose corrections where the implementation deliberately
+diverged, repaired stale refs, and the coverage update on a completed
+greenfield. The met/gap report goes to the conversation — it pastes well
+into a PR description. It never stages files; new implementation paths must
+already be staged or committed before they can be used as evidence.
+
+## How it works
+
+Each planned scenario's Trigger, Steps, and Outcome is the acceptance
+contract. The skill also verifies deleted behavior is absent and checks
+changed access, entry points, capability boundaries, and relationships on
+higher-level entities. It records **met**, **gap**, or **unverifiable** for
+implementation-bearing work and explicitly classifies product-only work as
+**map-only**, then runs the validator through its bundled isolated runner.
+Completion requires all implementation-bearing work to be met, all map-only
+work to be classified, coverage to be off `draft`, no validation errors, and
+no missing-evidence warnings; a draft map's zero exit status alone is not
+completion.
+
+## Guardrails
+
+- Never marks a scenario met without direct evidence; tests corroborate but
+  documentation alone proves nothing.
+- Never deletes or waters down planned claims to force validation green.
+- Never modifies implementation code, never executes target code, never
+  contacts the platform.
+
+Tutorial: [Ship a feature](./tutorial-ship-a-feature.md).

--- a/docs/skills.md
+++ b/docs/skills.md
@@ -1,60 +1,44 @@
 ---
-title: Skills reference
-description: The six BusinessLens agent skills — what each does and when to use it.
-order: 5
+title: Overview
+description: The eight BusinessLens agent skills — which one fits which situation.
+section: open-source
+group: Skills
+order: 11
 ---
 
-# Skills reference
+# Skills overview
 
-BusinessLens ships six agent skills. Each is self-contained, follows the open
-Agent Skills folder format, and treats the target repository as untrusted:
-skills inspect code statically and never execute it.
+BusinessLens ships eight agent skills. Each is self-contained, follows the
+open Agent Skills folder format, and treats the target repository as
+untrusted: skills inspect code statically and never execute it. Only
+`businesslens-publish` ever contacts the platform, and only on explicit
+request.
 
 | Skill | Use it when |
 | --- | --- |
-| `businesslens-init` | Adopting BusinessLens or rebuilding an incomplete map |
-| `businesslens-sync` | Code changes affected product behavior |
-| `businesslens-deep-dive` | One journey or experience needs exhaustive coverage |
-| `businesslens-validate` | The map needs a read-only deterministic check |
-| `businesslens-doctor` | The map fails validation, looks stale, or needs a health report |
-| `businesslens-publish` | You explicitly want to publish the map to the platform |
+| [`businesslens-init`](./skill-businesslens-init.md) | Adopting BusinessLens in a repository that already has code |
+| [`businesslens-plan`](./skill-businesslens-plan.md) | Planning a product (blank repo) or a feature (mapped repo) before code |
+| [`businesslens-verify`](./skill-businesslens-verify.md) | Planned map changes were implemented and need evidence-backed checking |
+| [`businesslens-sync`](./skill-businesslens-sync.md) | Code changed without a plan and the map drifted |
+| [`businesslens-deep-dive`](./skill-businesslens-deep-dive.md) | One journey or experience needs exhaustive coverage |
+| [`businesslens-validate`](./skill-businesslens-validate.md) | The map needs a read-only deterministic check |
+| [`businesslens-doctor`](./skill-businesslens-doctor.md) | The map fails validation, looks stale, or needs a health report |
+| [`businesslens-publish`](./skill-businesslens-publish.md) | You explicitly want the map on the platform |
 
-## businesslens-init
+## How they fit together
 
-Initializes Product-Driven Design in a repository: inspects the codebase and
-authors a complete, evidence-backed `.businesslens/` product map, installs the
-managed `AGENTS.md` guidance, and validates the result. Use it for first-time
-setup, replacing an incomplete scaffold, or rebuilding from scratch.
+The lifecycle runs through four of them: `init` (or `plan`, for a blank
+repository) creates the map, then every feature loops through `plan` →
+implement → `verify`. `sync` is the recovery lane when code changed without
+a plan. The rest are supporting tools: `deep-dive` adds depth to one area,
+`validate` and `doctor` keep the map honest, `publish` ships snapshots to
+the platform. The full decision table with situations lives in
+[How it works](./guide.md).
 
-## businesslens-sync
+## Invoking skills
 
-Refreshes an existing map after code or behavior changes — corrects affected
-entities and stale evidence without rebuilding unrelated areas. Invoke it
-after implementing features, fixing behavior, or removing functionality.
-
-## businesslens-deep-dive
-
-Expands one named journey or experience to exhaustive fidelity by mining its
-implementation and tests for scenarios, boundaries, and edge cases. Use it
-when a specific product area needs deeper coverage without remapping the
-repository.
-
-## businesslens-validate
-
-Runs the deterministic validator and explains every error, warning, and
-entity count. Strictly read-only — it never modifies files. Use it to check a
-map, verify initialization or synchronization, or confirm CI readiness.
-
-## businesslens-doctor
-
-Investigates the health of an installation and map: validation failures,
-stale `codeRefs`, missing managed instructions, semantic drift, and
-incomplete coverage. It diagnoses by default and repairs only when explicitly
-asked. Reach for it when a simple validation report is not enough.
-
-## businesslens-publish
-
-Compiles the map and submits it to the platform as a commit-pinned snapshot
-by running the CLI's `publish` command with preflight checks. It is the only
-skill that contacts the platform, and it never runs without explicit user
-intent. See the [CLI reference](./cli.md) for the underlying command.
+In Claude Code, Cursor, Gemini CLI, and GitHub Copilot, invoke a skill as
+`/businesslens-<name>`; in Codex as `$businesslens-<name>`. Skills accept
+free-text arguments — `/businesslens-plan quick: add dark mode` — and each
+page in this section documents its inputs, what it reads and writes, and
+its guardrails.

--- a/docs/tutorial-map-existing-product.md
+++ b/docs/tutorial-map-existing-product.md
@@ -1,0 +1,63 @@
+---
+title: Map existing code
+description: Build an evidence-backed product map of what your product does today.
+section: open-source
+group: Tutorials
+order: 7
+---
+
+# Map an existing product
+
+**Goal:** an evidence-backed `.businesslens/` map of what your product does
+today, so agents and reviewers start from product context instead of
+repository archaeology.
+
+**Prerequisites:** a Git repository with the product's code, Node.js
+20.12+, and an AI harness (Claude Code, Codex, Cursor, Gemini CLI, or
+GitHub Copilot).
+
+## Steps
+
+1. Install the skills in the repository:
+
+   ```bash
+   npx businesslens@latest install
+   ```
+
+2. Build the map in your harness:
+
+   ```text
+   /businesslens-init
+   ```
+
+   (Codex: `$businesslens-init`.) The skill inspects the code without
+   executing it, authors actors, experiences, domains, journeys, and
+   scenarios with `codeRefs`, and installs the managed `AGENTS.md` block.
+   Answer only the questions the code cannot — the skill drafts everything
+   it can from evidence.
+
+3. Review the diff like any pull request. Every behavioral claim carries a
+   `codeRef` you can open. Check `coverage.md` for honest gaps.
+
+4. Validate and commit:
+
+   ```bash
+   npx businesslens@latest validate
+   git add .businesslens AGENTS.md
+   git commit -m "docs: add BusinessLens product map"
+   ```
+
+5. Optional: deepen the highest-value area.
+
+   ```text
+   /businesslens-deep-dive <journey-id>
+   ```
+
+6. Add the validator to CI so the map cannot rot — see
+   [Validate in CI](./ci.md).
+
+## Outcome
+
+`npx businesslens validate` is green; the map describes today's product
+with evidence. From here, plan every new feature with
+[the feature loop](./tutorial-ship-a-feature.md).

--- a/docs/tutorial-plan-new-product.md
+++ b/docs/tutorial-plan-new-product.md
@@ -1,0 +1,85 @@
+---
+title: Plan a new product
+description: Blank repository — plan the whole product as a draft map, implement it, verify it, and watch the map become evidence-backed truth.
+section: open-source
+group: Tutorials
+order: 8
+---
+
+# Plan a new product from scratch
+
+**Goal:** a complete planned product before any code exists — and, once you
+build it, an evidence-backed map that grew straight out of the plan.
+
+**Prerequisites:** a fresh Git repository (`git init`), Node.js 20.12+, an
+AI harness, and the skills installed (`npx businesslens@latest install`).
+
+## Steps
+
+1. Start the guided planning dialogue:
+
+   ```text
+   /businesslens-plan
+   ```
+
+   With no map and no code, the skill runs the full product interview: why
+   the product exists, who it serves (actors), which surfaces it has
+   (experiences), which goals matter (journeys), and how each plays out
+   observably (scenarios with Trigger, Steps, Outcome). It proposes drafts
+   after every answer — you correct rather than dictate.
+
+2. Review what it authored: a complete `.businesslens/` map with **no
+   codeRefs** and `coverage.md` at `status: draft`. Validation is green with
+   warnings — a draft map is planned, not proven. Iterate by invoking
+   `/businesslens-plan` again with corrections, then commit:
+
+   ```bash
+   npx businesslens@latest validate
+   git add .businesslens AGENTS.md
+   git commit -m "plan: initial product map (draft)"
+   ```
+
+   If nobody ever implements it, this draft map is itself a portable,
+   validated product design — plain Markdown you can hand to anyone.
+
+3. Implement with your coding agent, pointing it at the map as the product
+   spec:
+
+   ```text
+   Implement the product described in .businesslens/ — the journeys and
+   scenarios are the behavior contract.
+   ```
+
+   Before verification, stage every new or changed implementation file with
+   `git add <paths>` (replace `<paths>` with the actual files and review the
+   staged diff). BusinessLens never changes the Git index itself, and
+   `codeRefs` can cite only paths already returned by `git ls-files`.
+
+4. Verify the implementation against the plan:
+
+   ```text
+   /businesslens-verify
+   ```
+
+   Every planned addition, change, and removal gets a verdict — met with
+   evidence, or a gap with expected-versus-found. Gaps are the remaining
+   to-do list; fix and re-run until everything is met. On success the skill
+   attaches `codeRefs` to every journey and scenario and moves `coverage.md`
+   off `draft`.
+
+5. Validate and commit:
+
+   ```bash
+   npx businesslens@latest validate
+   git add .businesslens
+   git commit -m "feat: verify implementation against the planned map"
+   ```
+
+   The commit includes the implementation staged in step 3 and the verified
+   map staged here.
+
+## Outcome
+
+A green, evidence-backed map born from the plan. From here the product uses
+the same loop as any mapped repository —
+[plan and ship a feature](./tutorial-ship-a-feature.md).

--- a/docs/tutorial-recover-from-drift.md
+++ b/docs/tutorial-recover-from-drift.md
@@ -1,0 +1,61 @@
+---
+title: Recover from drift
+description: Make the map true again after unplanned changes — sync, doctor, and getting back to the loop.
+section: open-source
+group: Tutorials
+order: 10
+---
+
+# Recover when code changed without a plan
+
+**Goal:** the map matches reality again after code changed outside the
+plan → implement → verify loop — a hotfix, a refactor that moved evidence,
+or a feature that skipped planning.
+
+**Prerequisites:** a repository with an existing `.businesslens/` map.
+
+## Steps
+
+1. Detect the drift:
+
+   ```bash
+   npx businesslens@latest validate
+   ```
+
+   Broken `codeRefs` and structural errors surface here. For semantic drift
+   (the code does something the map does not say), run:
+
+   ```text
+   /businesslens-doctor
+   ```
+
+   Doctor classifies findings — blocking, drift, coverage, hygiene — and
+   proposes an ordered repair plan without changing files.
+
+2. Repair the map:
+
+   ```text
+   /businesslens-sync
+   ```
+
+   Sync scopes the drift from the diff and updates only affected entities:
+   revised prose and evidence, the smallest justified new entities, deleted
+   obsolete ones, repaired `codeRefs`.
+
+3. Validate and commit:
+
+   ```bash
+   npx businesslens@latest validate
+   git add .businesslens
+   git commit -m "docs: resync product map"
+   ```
+
+4. Return to the loop. Drift means work bypassed planning; the durable fix
+   is upstream — describe the next feature in the map first
+   (`/businesslens-plan`) and let CI validation catch the map going stale.
+
+## Outcome
+
+A green, truthful map — and a clear boundary: sync is the recovery lane,
+not the routine. Planned work goes through
+[the feature loop](./tutorial-ship-a-feature.md).

--- a/docs/tutorial-ship-a-feature.md
+++ b/docs/tutorial-ship-a-feature.md
@@ -1,0 +1,84 @@
+---
+title: Ship a feature
+description: The feature loop — describe intended behavior in the map, implement, verify with evidence, merge green.
+section: open-source
+group: Tutorials
+order: 9
+---
+
+# Plan and ship a feature
+
+**Goal:** ship a feature so the plan, the implementation check, and the
+updated map are all reviewable in one branch — with git as the change
+model.
+
+**Prerequisites:** a repository with a green `.businesslens/` map (see
+[Map an existing product](./tutorial-map-existing-product.md)) and the
+skills installed.
+
+## Steps
+
+1. On a feature branch, plan in the map:
+
+   ```text
+   /businesslens-plan add guest checkout to the storefront
+   ```
+
+   The skill reads the affected map areas and edits them to the intended
+   state — new or revised journeys and scenarios, updated experiences,
+   retired entities removed. Say `quick` for minimal questions or
+   `thorough` for the full interview. Planned behavior gets **no**
+   codeRefs; after planning, `validate` lists new unevidenced journeys and
+   scenarios as `needs at least one codeRef`. Those findings are the evidence
+   checklist and stay red on purpose; the full map diff also records changed
+   and retired entities for verification.
+
+2. Commit the plan. This is the moment to agree on *what* before the how:
+
+   ```bash
+   git add .businesslens
+   git commit -m "plan: guest checkout"
+   ```
+
+   The map diff in the pull request shows reviewers the product delta in
+   plain Markdown.
+
+3. Implement with your coding agent, using the planned journeys and
+   scenarios as the behavior contract (and your SDD tool for the technical
+   design — link it from the map with `links: rel: spec`).
+
+   Before verification, stage every new or changed implementation file with
+   `git add <paths>` (replace `<paths>` with the actual files and review the
+   staged diff). BusinessLens never changes the index, and `codeRefs` can cite
+   only paths already returned by `git ls-files`.
+
+4. Verify:
+
+   ```text
+   /businesslens-verify
+   ```
+
+   The skill diffs the map against the merge base, checks every planned
+   addition, change, and removal against the code, attaches `codeRefs` for
+   what's met, and reports gaps as expected-versus-found. If you changed the
+   plan while implementing, just re-run — the diff recomputes. Fix gaps and
+   repeat until verification is complete:
+
+   ```bash
+   npx businesslens@latest validate
+   git add .businesslens
+   git commit -m "feat: guest checkout, verified against the map"
+   ```
+
+   The commit includes the implementation staged in step 3 and the verified
+   map staged here.
+
+5. Open the pull request. CI validation gates it (see
+   [Validate in CI](./ci.md)); merging green means the map and the code
+   agree.
+
+## Outcome
+
+The map describes the new behavior with evidence, the branch history
+records what was planned versus what shipped, and nothing about the
+workflow existed outside git.

--- a/docs/validation-rules.md
+++ b/docs/validation-rules.md
@@ -1,0 +1,112 @@
+---
+title: Validation rules
+description: Every businesslens validate error and warning — what it means and how to fix it.
+section: open-source
+group: Reference
+order: 22
+---
+
+# Validation rules
+
+`npx businesslens validate` is deterministic: the same map always produces
+the same findings. This page lists every finding with its meaning and fix.
+Exit codes: `0` when there are no errors (warnings may remain), `1` for
+validation failure, and `2` for invalid usage.
+
+One rule of thumb first: on a feature branch,
+`needs at least one codeRef` errors on entities you just planned are **not
+a problem** — they are the evidence checklist, and
+[`businesslens-verify`](./skill-businesslens-verify.md) clears them by
+attaching evidence.
+
+## Loading errors
+
+Reported when files cannot be read into the model at all.
+
+- `.businesslens/ does not exist — invoke the businesslens-init skill first`
+  — no map yet. Run `businesslens-init` (existing code) or
+  `businesslens-plan` (blank repository).
+- `config.yaml is missing` / `product.md is missing` /
+  `coverage.md is missing` / `taxonomies.yaml is missing` — a required
+  top-level file is absent. Restore it from the
+  [format contract](./format.md).
+- `config.yaml failed to parse (…)` / `taxonomies.yaml failed to parse (…)`
+  — invalid YAML; the parser's message pinpoints the line.
+- `taxonomies.yaml must contain a scenarioKinds list` — the file exists but
+  has no `scenarioKinds:` sequence.
+- `journeys/<id>/ is missing journey.md` — a journey directory without its
+  journey file. Add `journey.md` or delete the directory.
+- `<file>: frontmatter is not terminated with ---` /
+  `frontmatter must be a YAML mapping` /
+  `frontmatter YAML failed to parse (…)` — malformed frontmatter block.
+- `<file>: unknown frontmatter key "<key>"` — the schema is a strict
+  allowlist; typos fail loudly. Check the entity's allowed keys in the
+  [format contract](./format.md).
+- `<file>: "<key>" must be a string` / `must be a list of strings` /
+  `"entryPoints" must be a list` /
+  `each entry point must be a single "type: path" map` /
+  `"links" must be a list` / `each link needs "rel" and "href"` — a
+  frontmatter value has the wrong shape.
+- `<file>: link rel "<rel>" must be one of spec|proposal|doc|adr` — an
+  unsupported link relation.
+- `<file>: empty codeRef` / `codeRef "…" has no path` /
+  `must be repository-relative` / `has an empty symbol` /
+  `has an inverted line range` — the codeRef grammar is
+  `path[#symbol][:start[-end]]` with repository-relative paths.
+
+## Structure errors
+
+- `product.md: missing id` / `id must be lowercase kebab-case` — the
+  product manifest needs a kebab-case `id`.
+- `<collection>: id "<id>" must be lowercase kebab-case` — entity IDs are
+  filename stems and must match `^[a-z0-9]+(?:-[a-z0-9]+)*$`.
+- `<file>: missing H1 title` / `missing lead paragraph (description)` —
+  every entity needs a `# Heading` and prose before the first `##`.
+- `coverage.md: status "…" must be complete|partial|draft` — the only
+  allowed coverage states.
+- `<experience>: access "…" must be public|authenticated|restricted` — the
+  only allowed access modes.
+- `<scenario>: kind "…" is not defined in taxonomies.yaml` — add the kind
+  to `taxonomies.yaml` or use an existing one.
+- `<scenario>: missing "## Trigger" section` /
+  `"## Steps" needs at least one ordered item` /
+  `missing "## Outcome" section` — scenarios are structured: Trigger
+  paragraph, ordered Steps list, Outcome paragraph.
+
+## Relationship errors
+
+- `references missing actor "…"` / `missing domain "…"` /
+  `missing experience "…"` — a frontmatter relation points at an entity
+  that does not exist. Create it or fix the ID.
+- `needs at least one actor` / `must belong to at least one experience` /
+  `needs at least one scenario` — journeys and experiences have minimum
+  relations; empty ones are not product claims.
+- `scenario id "…" already used in <journey> (ids are global)` — scenario
+  IDs are unique across the whole map, so every scenario is addressable.
+  Rename one of them.
+- `experiences/: the map needs at least one experience` — an empty map is
+  only valid transiently; build it with `businesslens-init` or plan it with
+  `businesslens-plan`.
+
+## Evidence errors and the draft rule
+
+- `<journey or scenario>: needs at least one codeRef` — a behavioral claim
+  without evidence. On the default branch this is drift or an unverified
+  merge; on a feature branch it is the planning evidence checklist —
+  `businesslens-verify` attaches the evidence after implementation.
+- `codeRef path "…" is not a tracked file` — every codeRef path must exist
+  in `git ls-files`. Fix the path, commit the file, or remove the stale
+  ref.
+- While `coverage.md` has `status: draft` (a planned greenfield map),
+  missing codeRefs appear as **warnings** instead —
+  `needs at least one codeRef before coverage can leave draft` — and the
+  map stays green. `build` and `publish` refuse draft maps.
+
+## Warnings
+
+Warnings never fail validation.
+
+- `link href "…" does not exist in the repository` — a local `links:`
+  target is missing; fix the path or drop the link.
+- `needs at least one codeRef before coverage can leave draft` — see the
+  draft rule above.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "businesslens",
   "version": "0.5.0",
-  "description": "Product-Driven Design for coding agents: a git-tracked product map in .businesslens/, built from code evidence.",
+  "description": "Product-Driven Development for coding agents: a git-tracked product map in .businesslens/, built from code evidence.",
   "type": "module",
   "license": "MIT",
   "repository": {

--- a/scripts/check-repo.mjs
+++ b/scripts/check-repo.mjs
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
-import { readFile, access } from 'node:fs/promises'
+import { readFile, readdir, access } from 'node:fs/promises'
 import { resolve } from 'node:path'
+import { parse as parseYaml } from 'yaml'
 
 const root = process.cwd()
 const errors = []
@@ -29,6 +30,8 @@ const plugin = JSON.parse(await readFile(resolve(root, '.claude-plugin/plugin.js
 const marketplace = JSON.parse(await readFile(resolve(root, '.claude-plugin/marketplace.json'), 'utf8'))
 const expectedSkills = [
   'businesslens-init',
+  'businesslens-plan',
+  'businesslens-verify',
   'businesslens-sync',
   'businesslens-deep-dive',
   'businesslens-validate',
@@ -90,6 +93,52 @@ for (const skillPath of plugin.skills || []) {
   }
   if (!await exists(`${dir}/agents/openai.yaml`)) {
     errors.push(`${dir}/agents/openai.yaml is missing`)
+  }
+}
+
+// Docs frontmatter contract, consumed by the landing repository's nav:
+// section = top-level tab, group = sidebar cluster, order = global within section.
+const DOC_SECTIONS = new Set(['open-source', 'platform'])
+const docFiles = (await readdir(resolve(root, 'docs'))).filter(name => name.endsWith('.md')).sort()
+const docOrders = new Map()
+for (const name of docFiles) {
+  const source = await readFile(resolve(root, `docs/${name}`), 'utf8')
+  const match = source.match(/^---\n([\s\S]*?)\n---/)
+  if (!match) {
+    errors.push(`docs/${name} is missing frontmatter`)
+    continue
+  }
+  let data
+  try {
+    data = parseYaml(match[1])
+  } catch (error) {
+    errors.push(`docs/${name} frontmatter is invalid YAML (${error.message})`)
+    continue
+  }
+  if (!data || typeof data !== 'object' || Array.isArray(data)) {
+    errors.push(`docs/${name} frontmatter must be a YAML mapping`)
+    continue
+  }
+  for (const key of ['title', 'description', 'section', 'group']) {
+    if (typeof data[key] !== 'string' || !data[key].trim()) {
+      errors.push(`docs/${name} frontmatter is missing "${key}"`)
+    }
+  }
+  const section = data.section
+  if (section && !DOC_SECTIONS.has(section)) {
+    errors.push(`docs/${name} section "${section}" must be one of: ${[...DOC_SECTIONS].join('|')}`)
+  }
+  const order = data.order
+  if (!Number.isInteger(order) || order < 1) {
+    errors.push(`docs/${name} order must be a positive integer`)
+  } else if (DOC_SECTIONS.has(section)) {
+    const key = `${section}:${order}`
+    const previous = docOrders.get(key)
+    if (previous) {
+      errors.push(`docs/${name} order ${order} duplicates docs/${previous} in section "${section}"`)
+    } else {
+      docOrders.set(key, name)
+    }
   }
 }
 

--- a/skills/businesslens-doctor/SKILL.md
+++ b/skills/businesslens-doctor/SKILL.md
@@ -17,6 +17,9 @@ Diagnose without changing files unless the user explicitly asks for repair.
    - unresolved actors, experiences, domains, kinds, or scenario IDs;
    - `codeRefs` whose paths no longer exist in `git ls-files`;
    - journeys without scenarios or experiences;
+   - evidence-less journeys or scenarios sitting on the default branch, or
+     `coverage.md` stuck in `draft` after implementation shipped — planned
+     work that never went through `businesslens-verify`;
    - placeholder prose, unsupported certainty, or weak coverage claims;
    - generated `cache/` content accidentally tracked by Git.
 4. Check root `AGENTS.md` for one well-formed

--- a/skills/businesslens-init/SKILL.md
+++ b/skills/businesslens-init/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: businesslens-init
-description: Initialize Product-Driven Design in a repository by inspecting the codebase and building a complete, evidence-backed .businesslens/ product map. Use for first-time BusinessLens setup, replacing an incomplete scaffold, or rebuilding the map from scratch.
+description: Initialize Product-Driven Design in a repository by inspecting the codebase and building a complete, evidence-backed .businesslens/ product map. Use for first-time BusinessLens setup, replacing an incomplete scaffold, or rebuilding the map from scratch; use businesslens-plan for a blank repository with no code to map.
 ---
 
 # Initialize BusinessLens
@@ -18,6 +18,9 @@ Read these references before authoring:
 
 1. Confirm the working directory is a Git repository. Never execute the
    repository's application, build, migrations, or tests; inspect files only.
+   If the repository contains no meaningful implementation to describe, stop
+   and direct the user to `businesslens-plan` — a new product is planned as
+   a draft map, not initialized from empty code.
 2. Inspect existing instructions and product material first: `AGENTS.md`,
    `CLAUDE.md`, READMEs, documentation, architecture notes, and any SDD roots
    such as `openspec/`, `specs/`, or `.kiro/`.
@@ -62,7 +65,8 @@ Read these references before authoring:
    This repository maintains its product truth in `.businesslens/` (Product-Driven Design).
 
    - **Before** building or changing behavior: read the relevant experience/journey/scenario files to understand current behavior and where it lives (`codeRefs`).
-   - **After** changing user-facing behavior: update the affected entity files and run `npx businesslens validate`.
+   - **Plan** product changes by updating the map first (`businesslens-plan`), implement, then attach evidence with `businesslens-verify`.
+   - **After** unplanned behavior changes: update the affected entity files and run `npx businesslens validate`.
    - Never edit `.businesslens/cache/` — generated.
    <!-- businesslens:end -->
    ```

--- a/skills/businesslens-init/SKILL.md
+++ b/skills/businesslens-init/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: businesslens-init
-description: Initialize Product-Driven Design in a repository by inspecting the codebase and building a complete, evidence-backed .businesslens/ product map. Use for first-time BusinessLens setup, replacing an incomplete scaffold, or rebuilding the map from scratch; use businesslens-plan for a blank repository with no code to map.
+description: Initialize Product-Driven Development in a repository by inspecting the codebase and building a complete, evidence-backed .businesslens/ product map. Use for first-time BusinessLens setup, replacing an incomplete scaffold, or rebuilding the map from scratch; use businesslens-plan for a blank repository with no code to map.
 ---
 
 # Initialize BusinessLens
@@ -62,7 +62,7 @@ Read these references before authoring:
    <!-- businesslens:begin -->
    ## BusinessLens product map
 
-   This repository maintains its product truth in `.businesslens/` (Product-Driven Design).
+   This repository maintains its product truth in `.businesslens/` (Product-Driven Development).
 
    - **Before** building or changing behavior: read the relevant experience/journey/scenario files to understand current behavior and where it lives (`codeRefs`).
    - **Plan** product changes by updating the map first (`businesslens-plan`), implement, then attach evidence with `businesslens-verify`.

--- a/skills/businesslens-plan/SKILL.md
+++ b/skills/businesslens-plan/SKILL.md
@@ -1,0 +1,86 @@
+---
+name: businesslens-plan
+description: Plan product behavior directly in the .businesslens/ product map before implementation — a fully guided product definition for a blank repository, or a quick-or-thorough feature-planning dialogue on an existing map. Use when the user wants to plan, design, or specify a product or a feature; use businesslens-init to map an existing codebase.
+---
+
+# Plan in the product map
+
+Planning is editing the map to describe intended behavior. Git is the change
+model: the branch holds the plan, `businesslens-verify` attaches evidence
+after implementation, and the verified map returns to evidence-backed truth.
+
+Read these references before authoring:
+
+- [references/format.md](references/format.md) — entity shapes, the draft
+  rule, and the greenfield scaffold.
+- [references/planning-rubric.md](references/planning-rubric.md) — what good
+  entities and scenarios look like.
+
+## Workflow
+
+1. Confirm the working directory is a Git repository. Never execute the
+   repository's application, build, migrations, or tests; inspect files only.
+2. Detect the situation:
+   - `.businesslens/` map exists → **feature planning** (step 5).
+   - No map and no meaningful implementation → **new product** (step 3).
+   - No map but implementation exists → stop; direct the user to
+     `businesslens-init` to map today's truth first, then re-run this skill
+     for the feature. Never plan against unmapped code.
+3. New product — run the full guided interview. Cover, in order, and batch
+   the questions: the product (name, one-paragraph why), actors (who, by
+   goals), experiences (surfaces, access, entry points, exit), domains,
+   journeys (one per stable user goal), scenarios per journey (primary path
+   plus the failure paths that matter; each with Trigger, ordered Steps,
+   Outcome), and known limitations. Propose concrete drafts after each
+   answer; the user corrects rather than dictates.
+4. New product — scaffold and author the whole map: `config.yaml`
+   (`schema: 1`, empty `sdd.paths`, no platform), `taxonomies.yaml`,
+   `product.md`, `.gitignore`, every entity file **without codeRefs**, and
+   `coverage.md` with `status: draft` and a method noting the map was
+   planned before implementation. Insert the managed `AGENTS.md` block from
+   `references/format.md`. Continue at step 7.
+5. Feature planning — choose depth. If the user says `quick` or `thorough`,
+   honor it; otherwise infer: a small, well-specified ask is quick, a vague
+   or cross-cutting one is thorough.
+   - **quick** — read the affected map areas, draft the plan yourself, and
+     ask at most three batched questions covering only decisions the map and
+     repository cannot answer.
+   - **thorough** — full interview: why, who, which surfaces, which
+     journeys, the scenario space (success, permission, validation,
+     conflict, external failure), what gets removed, and done-when.
+6. Feature planning — edit the living map on the current branch to the
+   intended state: add or revise journeys, scenarios, experiences, actors,
+   and domains; keep still-valid `codeRefs` on modified entities; add **no**
+   codeRefs for unbuilt behavior; add missing scenario kinds to
+   `taxonomies.yaml`; delete entities the change retires and repair reverse
+   relations.
+7. Resolve `<businesslens-plan-skill-dir>` to this installed skill directory,
+   then run the bundled validator outside the untrusted target:
+
+   ```bash
+   node <businesslens-plan-skill-dir>/scripts/run-businesslens.mjs \
+     --root "$PWD" validate --json
+   ```
+
+   Fix every finding except expected `needs at least one codeRef` results on
+   newly unevidenced journeys and scenarios (errors on a brownfield branch,
+   warnings on a draft map). Those findings are the evidence checklist —
+   leave them. Do not treat their absence as proof that a modified or deleted
+   entity needs no implementation work; the map diff is the full plan.
+8. Report: what was planned (entities added, changed, removed), open
+   questions recorded, the full implementation worklist, the missing-evidence
+   subset, and the next steps — implement, then `businesslens-verify`; commit
+   the planned map to the working branch. For a design nobody will implement
+   yet, the planned map itself is the deliverable.
+
+## Guardrails
+
+- Never invent implementation detail — no stacks, endpoints, schemas, or
+  file names in entity prose.
+- Never add a `codeRef` for behavior that does not exist, and never point at
+  an untracked path. Planned behavior carries no evidence, not fake evidence.
+- Never weaken or delete evidenced current truth except where the plan
+  deliberately retires it — and say so in the report.
+- Never present planned behavior as current; unevidenced entities are open
+  work by definition.
+- Never execute target code; never publish or contact the platform.

--- a/skills/businesslens-plan/agents/openai.yaml
+++ b/skills/businesslens-plan/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "BusinessLens Plan"
+  short_description: "Plan a product or feature in the product map"
+  default_prompt: "Use $businesslens-plan to plan this product or feature directly in the BusinessLens product map before implementation."

--- a/skills/businesslens-plan/references/format.md
+++ b/skills/businesslens-plan/references/format.md
@@ -1,0 +1,63 @@
+# BusinessLens planning format
+
+Planned behavior lives in the same map as current behavior. The only
+difference is evidence: planned journeys and scenarios carry **no**
+`codeRefs` until `businesslens-verify` attaches them after implementation.
+
+- On an existing map (coverage `partial`/`complete`), `validate` reports new
+  unevidenced journeys and scenarios as errors:
+  `needs at least one codeRef`. That is the expected planning end state for
+  those entities — the evidence checklist. The complete plan is the map
+  diff, including modified and deleted entities that may produce no
+  missing-evidence finding.
+- On a new product, `coverage.md` `status: draft` marks the whole map as
+  planned: the same findings appear as warnings and validation stays green.
+  `build`/`publish` refuse draft maps.
+
+## Entity shapes
+
+- IDs are lowercase kebab-case filename stems; a journey ID is its directory
+  name. Never write `id:` in entity frontmatter (only `product.md` has one).
+- Actors: `actors/<id>.md` — no required frontmatter; H1 name + lead.
+- Domains: `domains/<id>.md` — optional `colorSlot`; H1 name + lead.
+- Experiences: `experiences/<id>.md` — `actors`, `access`
+  (`public|authenticated|restricted`), `entryPoints` (compact `type: path`
+  items), `exit`, H1 + lead, and a `## Capability boundary` section.
+- Journeys: `journeys/<id>/journey.md` — `domain`, `actors`, `experiences`,
+  optional `entryPoints`; H1 + lead summary; needs at least one scenario.
+- Scenarios: `journeys/<jid>/scenarios/<id>.md` — taxonomy `kind`, H1,
+  `## Trigger` (paragraph), `## Steps` (ordered list, ≥1), `## Outcome`
+  (paragraph), optional `## Edge cases` (bullets). Scenario IDs are globally
+  unique across the whole map.
+- `codeRefs` grammar is `path[#symbol][:start[-end]]`; every path present
+  must be Git-tracked. During planning, omit them entirely for new behavior
+  and keep only still-valid ones on modified entities.
+- Optional `links:` (`rel: spec|proposal|doc|adr`) connect entities to SDD
+  specs and design docs; link technical designs instead of describing them.
+
+## Greenfield scaffold (new product)
+
+- `config.yaml`: `schema: 1` and `sdd:\n  paths: []`. No platform block.
+- `taxonomies.yaml`: at least `primary` and `edge` scenario kinds.
+- `product.md`: `id`, `tags`, `limitations`, H1 name, lead description.
+- `coverage.md`: `status: draft`, method noting the map was planned before
+  implementation, empty `sourceAreas`.
+- `.gitignore`: `build/` and `cache/`.
+
+## Managed `AGENTS.md` block
+
+Insert (or leave intact) exactly one such block in the repository root
+`AGENTS.md`, preserving everything outside the markers:
+
+```markdown
+<!-- businesslens:begin -->
+## BusinessLens product map
+
+This repository maintains its product truth in `.businesslens/` (Product-Driven Design).
+
+- **Before** building or changing behavior: read the relevant experience/journey/scenario files to understand current behavior and where it lives (`codeRefs`).
+- **Plan** product changes by updating the map first (`businesslens-plan`), implement, then attach evidence with `businesslens-verify`.
+- **After** unplanned behavior changes: update the affected entity files and run `npx businesslens validate`.
+- Never edit `.businesslens/cache/` — generated.
+<!-- businesslens:end -->
+```

--- a/skills/businesslens-plan/references/format.md
+++ b/skills/businesslens-plan/references/format.md
@@ -53,7 +53,7 @@ Insert (or leave intact) exactly one such block in the repository root
 <!-- businesslens:begin -->
 ## BusinessLens product map
 
-This repository maintains its product truth in `.businesslens/` (Product-Driven Design).
+This repository maintains its product truth in `.businesslens/` (Product-Driven Development).
 
 - **Before** building or changing behavior: read the relevant experience/journey/scenario files to understand current behavior and where it lives (`codeRefs`).
 - **Plan** product changes by updating the map first (`businesslens-plan`), implement, then attach evidence with `businesslens-verify`.

--- a/skills/businesslens-plan/references/planning-rubric.md
+++ b/skills/businesslens-plan/references/planning-rubric.md
@@ -1,0 +1,39 @@
+# Planning rubric
+
+## Scope
+
+- Plan one coherent intent at a time — something a reviewer can approve or
+  reject as a whole on one branch. Split anything that could ship
+  separately.
+- Prefer the smallest well-defined plan over a speculative epic.
+
+## Entities
+
+- Actors are defined by goals or privileges, never by UI screens.
+- Journeys express stable user or operator goals; scenarios are observable
+  paths through a goal, not implementation branches.
+- Cover the scenario space deliberately: primary success, permission or
+  authorization failure, validation failure, conflict, and external-failure
+  paths — when the planned behavior genuinely distinguishes them.
+- Keep prose at product altitude: what a user observes, not how the system
+  achieves it.
+
+## Scenarios are the acceptance contract
+
+`businesslens-verify` will check the implementation against each scenario's
+Trigger, Steps, and Outcome. Write them so a reviewer could check them
+against source code without executing anything:
+
+- Good: "Submitting an empty cart shows an error and keeps the cart."
+- Too vague: "Cart validation works."
+- Wrong altitude: "POST /cart returns 400."
+
+A scenario that yields nothing checkable is too vague to plan.
+
+## Dialogue
+
+- Propose concrete drafts and let the user correct them; do not interrogate
+  from a blank page.
+- Batch open questions; ask only what the user must actually decide.
+- Record undecided points as limitations or open questions in the report
+  rather than guessing.

--- a/skills/businesslens-plan/scripts/run-businesslens.mjs
+++ b/skills/businesslens-plan/scripts/run-businesslens.mjs
@@ -1,0 +1,66 @@
+#!/usr/bin/env node
+
+import { execFileSync } from 'node:child_process'
+import { mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join, resolve } from 'node:path'
+
+function fail(message) {
+  process.stderr.write(`${message}\n`)
+  process.exit(2)
+}
+
+const args = process.argv.slice(2)
+const rootIndex = args.indexOf('--root')
+const requestedRoot = rootIndex >= 0 ? args[rootIndex + 1] : undefined
+if (!requestedRoot) {
+  fail('Usage: run-businesslens.mjs --root <repository> validate [--json]')
+}
+
+const commandArgs = args.filter(
+  (_, index) => index !== rootIndex && index !== rootIndex + 1
+)
+if (commandArgs[0] !== 'validate') {
+  fail('The isolated BusinessLens runner supports only validate.')
+}
+
+let root
+try {
+  root = resolve(execFileSync(
+    'git',
+    ['-C', resolve(requestedRoot), 'rev-parse', '--show-toplevel'],
+    { encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'] }
+  ).trim())
+} catch {
+  fail('The BusinessLens runner must target a Git repository.')
+}
+
+const runnerRoot = mkdtempSync(join(tmpdir(), 'businesslens-cli-'))
+const env = { ...process.env }
+delete env.BUSINESSLENS_API_KEY
+
+try {
+  execFileSync(
+    'npm',
+    [
+      'exec',
+      '--yes',
+      '--ignore-scripts',
+      '--package=businesslens@latest',
+      '--',
+      'businesslens',
+      '--cwd',
+      root,
+      ...commandArgs
+    ],
+    {
+      cwd: runnerRoot,
+      env,
+      stdio: 'inherit'
+    }
+  )
+} catch (error) {
+  process.exitCode = typeof error.status === 'number' ? error.status : 1
+} finally {
+  rmSync(runnerRoot, { recursive: true, force: true })
+}

--- a/skills/businesslens-sync/SKILL.md
+++ b/skills/businesslens-sync/SKILL.md
@@ -1,11 +1,14 @@
 ---
 name: businesslens-sync
-description: Refresh an existing .businesslens/ product map after code or behavior changes, correcting affected entities and stale evidence without rebuilding unrelated areas. Use after implementing features, fixing behavior, removing functionality, or when the map has drifted.
+description: Repair an existing .businesslens/ product map after code changed without the map being planned first, correcting affected entities and stale evidence without rebuilding unrelated areas. Use when the map has drifted from unplanned work; for planned work use businesslens-plan before implementing and businesslens-verify after.
 ---
 
 # Synchronize the product map
 
-Update only the product truth affected by the repository changes.
+Recover map truth after unplanned code changes. The primary loop is plan
+(update the map) → implement → verify; sync is the repair lane for
+everything that bypassed it. Update only the product truth affected by the
+repository changes.
 
 Read [references/format.md](references/format.md) and
 [references/evidence-policy.md](references/evidence-policy.md) before editing.

--- a/skills/businesslens-sync/agents/openai.yaml
+++ b/skills/businesslens-sync/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "BusinessLens Sync"
-  short_description: "Refresh the product map after code changes"
-  default_prompt: "Use $businesslens-sync to update the BusinessLens product map for the changes in this repository."
+  short_description: "Repair drift after unplanned code changes"
+  default_prompt: "Use $businesslens-sync to repair the BusinessLens product map after unplanned code changes caused drift."

--- a/skills/businesslens-validate/SKILL.md
+++ b/skills/businesslens-validate/SKILL.md
@@ -33,6 +33,10 @@ Do not modify files.
    - **Counts** — actors, experiences, domains, journeys, and scenarios;
    - **Next action** — none for a clean result, `businesslens-init` for a
      missing map, or `businesslens-doctor` when diagnosis or repair is needed.
+   `needs at least one codeRef` findings usually mean planned behavior whose
+   implementation has not been verified yet — the next action there is
+   `businesslens-verify` (they appear as warnings while `coverage.md` is
+   `status: draft`, the planned-greenfield state).
 5. When explaining a finding, read the referenced authored file if necessary
    to provide context. Do not broaden this into a semantic coverage or drift
    audit.

--- a/skills/businesslens-verify/SKILL.md
+++ b/skills/businesslens-verify/SKILL.md
@@ -1,0 +1,97 @@
+---
+name: businesslens-verify
+description: Statically verify that the implementation delivers the product behavior planned in the .businesslens/ map — diff the map against the merge base, check every planned addition/change/removal, attach codeRefs, and report a verdict per work item. Use after implementing planned map changes and before merging; use businesslens-sync when code changed without a plan.
+---
+
+# Verify implementation against the plan
+
+Close the gap between what the map claims and what the code proves. The
+scenario contract (Trigger, Steps, Outcome) is the acceptance criteria.
+
+Read [references/format.md](references/format.md) and
+[references/evidence-policy.md](references/evidence-policy.md) before
+verifying.
+
+## Workflow
+
+1. Confirm the working directory is a Git repository with a `.businesslens/`
+   map. Never execute the repository's application, build, migrations, or
+   tests; inspect files only. List untracked files with
+   `git ls-files --others --exclude-standard`. If implementation evidence
+   depends on an untracked file, stop and ask the user to stage or commit it;
+   never change the index yourself. A `codeRef` can cite only a path already
+   returned by `git ls-files`.
+2. Determine the comparison base: an explicit user-provided branch or ref
+   first; otherwise the merge base with the default branch (for example
+   `git merge-base HEAD origin/main`); on a repository with no base to
+   compare against, treat the whole map as planned.
+3. Build the verification worklist, fresh on every run — the plan may have
+   evolved while implementing, so never reuse an earlier report:
+   - every authored map file added, modified, **or deleted** in
+     `git diff <base>...HEAD -- .businesslens/`, plus uncommitted map edits;
+     retain the base version of a deleted entity as the removal contract;
+   - independently, every journey and scenario lacking `codeRefs`
+     (on a new `coverage: draft` map, that is initially the entire map).
+4. Verify every work item, not only extant scenarios:
+   - for added or changed scenarios, treat Trigger, Steps, Outcome, and edge
+     cases as the acceptance contract and trace the observable behavior;
+   - for deleted entities, use the base version and its old evidence to prove
+     the retired behavior, entry point, or surface is absent from the code;
+   - for changed experiences, actors, domains, journeys, product metadata,
+     or taxonomies, check each changed contract — especially access,
+     entry points, capability boundaries, and relationships — against direct
+     repository evidence. Explicitly classify vocabulary, organization,
+     configuration, or other product-only changes with no implementation
+     contract as map-only; never use that classification for observable
+     access, entry-point, capability, relationship, or behavior changes.
+5. Record one verdict per work item:
+   - **met** — direct implementation evidence proves the addition/change or
+     proves the planned removal; attach `codeRefs` (prefer `path#symbol`) to
+     extant scenarios and their journeys;
+   - **gap** — the new behavior is missing, diverges, or the retired behavior
+     is still implemented; state expected versus found and attach nothing;
+   - **unverifiable** — cannot be established from source alone; never
+     guess.
+   - **map-only** — no implementation change is required; identify the exact
+     product or organizational decision and why source evidence does not
+     apply.
+6. Where the implementation deliberately diverged and the user confirms it
+   is intended, correct the entity prose to the implemented truth and note
+   the correction in the report. Never silently rewrite the plan to match
+   the code.
+7. Repair `codeRefs` the implementation invalidated on modified entities.
+8. On a draft map, update `coverage.md` honestly off `draft` (`partial` or
+   `complete`) only after every planned journey and scenario has evidence and
+   every implementation-bearing addition, change, and removal on the
+   worklist is met, and every map-only item is explicitly classified.
+   Refresh `method`, `sourceAreas`, `unmapped`, and `limitations`. Leave it
+   `draft` while any gap or unverifiable verdict remains.
+9. Resolve `<businesslens-verify-skill-dir>` to this installed skill
+   directory, then run the bundled validator outside the untrusted target:
+
+   ```bash
+   node <businesslens-verify-skill-dir>/scripts/run-businesslens.mjs \
+     --root "$PWD" validate --json
+   ```
+
+   A zero exit status alone is not completion because a draft map reports
+   missing evidence as warnings. Verification is complete only when every
+   implementation-bearing work item is met, every map-only item is
+   classified, coverage is no longer `draft`, validation has no errors, and
+   no missing-evidence warning remains.
+10. Report in the conversation, grouped by journey and then other entity:
+    met/gap/unverifiable/map-only per work item with the evidence cited,
+    prose corrections made, coverage change, the validation result, and the
+    next step — fix the gaps and re-run, or commit and open the pull request
+    (the report pastes well into its description).
+
+## Guardrails
+
+- Never mark a scenario met without direct evidence; **unverifiable** is the
+  honest verdict when proof is out of reach.
+- Never delete or water down planned claims to force validation green; gaps
+  stay reported even when draft validation exits zero. Prose corrections
+  require the user's confirmation.
+- Never modify implementation code.
+- Never execute target repository code.
+- Never publish or contact the platform from this skill.

--- a/skills/businesslens-verify/agents/openai.yaml
+++ b/skills/businesslens-verify/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "BusinessLens Verify"
+  short_description: "Verify implementation against the planned map"
+  default_prompt: "Use $businesslens-verify to check this repository's implementation against the planned BusinessLens map changes and attach evidence."

--- a/skills/businesslens-verify/references/evidence-policy.md
+++ b/skills/businesslens-verify/references/evidence-policy.md
@@ -1,0 +1,15 @@
+# Evidence policy for verification
+
+- A scenario is met only when its observable behavior is implemented — a
+  similarly named function, route, or flag is not evidence by itself.
+- Trace the full path: entry point → handler/service → persistence or
+  external effect → the outcome the scenario names.
+- Tests corroborate evidence; they do not replace reading the
+  implementation. Documentation alone proves nothing.
+- Divergence from the planned behavior is a gap even when the implementation
+  is arguably better; record what was found and let the user decide whether
+  the plan changes.
+- Partial implementations are gaps, never rounded up to met.
+- Never claim live operational state (deployed configuration, external
+  systems, data) from source code alone — that verdict is unverifiable.
+- Prefer `path#symbol` codeRefs; do not invent line numbers.

--- a/skills/businesslens-verify/references/format.md
+++ b/skills/businesslens-verify/references/format.md
@@ -1,0 +1,25 @@
+# BusinessLens verification format
+
+- Planned behavior is simply map entities without evidence: journeys and
+  scenarios lacking `codeRefs`. On a map with coverage `partial`/`complete`
+  they validate as errors; on a `status: draft` map (planned greenfield
+  product) they validate as warnings.
+- The planned delta is derived, never stored: every added, modified, or
+  deleted authored file in `git diff <base>...HEAD -- .businesslens/`, plus
+  uncommitted edits, unioned with every evidence-less journey and scenario.
+  Retain the base content of deletions so removal can be verified. Re-derive
+  the delta on every run.
+- `codeRefs` use `path[#symbol][:start[-end]]`; every path must be tracked
+  by Git; prefer symbols over line numbers. Attach them to the scenario that
+  claims the behavior and to its journey. Ask the user to stage or commit any
+  new implementation file needed as evidence; never stage it yourself.
+- Scenario sections are the acceptance contract: `## Trigger` (paragraph),
+  `## Steps` (ordered list), `## Outcome` (paragraph), optional
+  `## Edge cases` (bullets).
+- `coverage.md` `status: draft` → `partial`/`complete` only when every
+  planned journey and scenario is evidenced, every implementation-bearing
+  addition/change/removal is met, and every product-only item is explicitly
+  classified as map-only; refresh `method`, `sourceAreas`, `unmapped`, and
+  `limitations` at the same time. `build`/`publish` refuse draft maps.
+- Verification writes only map files (`codeRefs`, confirmed prose
+  corrections, coverage). The met/gap report lives in the conversation.

--- a/skills/businesslens-verify/scripts/run-businesslens.mjs
+++ b/skills/businesslens-verify/scripts/run-businesslens.mjs
@@ -1,0 +1,66 @@
+#!/usr/bin/env node
+
+import { execFileSync } from 'node:child_process'
+import { mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join, resolve } from 'node:path'
+
+function fail(message) {
+  process.stderr.write(`${message}\n`)
+  process.exit(2)
+}
+
+const args = process.argv.slice(2)
+const rootIndex = args.indexOf('--root')
+const requestedRoot = rootIndex >= 0 ? args[rootIndex + 1] : undefined
+if (!requestedRoot) {
+  fail('Usage: run-businesslens.mjs --root <repository> validate [--json]')
+}
+
+const commandArgs = args.filter(
+  (_, index) => index !== rootIndex && index !== rootIndex + 1
+)
+if (commandArgs[0] !== 'validate') {
+  fail('The isolated BusinessLens runner supports only validate.')
+}
+
+let root
+try {
+  root = resolve(execFileSync(
+    'git',
+    ['-C', resolve(requestedRoot), 'rev-parse', '--show-toplevel'],
+    { encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'] }
+  ).trim())
+} catch {
+  fail('The BusinessLens runner must target a Git repository.')
+}
+
+const runnerRoot = mkdtempSync(join(tmpdir(), 'businesslens-cli-'))
+const env = { ...process.env }
+delete env.BUSINESSLENS_API_KEY
+
+try {
+  execFileSync(
+    'npm',
+    [
+      'exec',
+      '--yes',
+      '--ignore-scripts',
+      '--package=businesslens@latest',
+      '--',
+      'businesslens',
+      '--cwd',
+      root,
+      ...commandArgs
+    ],
+    {
+      cwd: runnerRoot,
+      env,
+      stdio: 'inherit'
+    }
+  )
+} catch (error) {
+  process.exitCode = typeof error.status === 'number' ? error.status : 1
+} finally {
+  rmSync(runnerRoot, { recursive: true, force: true })
+}

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -38,8 +38,10 @@ General options:
   --version                   Show the CLI version
 
 Agent workflows:
-  /businesslens-init          Build the initial product map
-  /businesslens-sync          Refresh the map after behavior changes
+  /businesslens-init          Build the initial product map from existing code
+  /businesslens-plan          Plan a product or feature in the product map
+  /businesslens-verify        Verify implementation against the planned map
+  /businesslens-sync          Repair the map after unplanned code changes
   /businesslens-deep-dive     Expand one journey or experience
   /businesslens-validate      Validate the map and explain every result
   /businesslens-doctor        Diagnose validation, drift, and coverage

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -8,7 +8,7 @@ import { runUpdate } from './commands/update.js'
 import { runValidate } from './commands/validate.js'
 import { cliVersion } from './version.js'
 
-const HELP = `businesslens — Product-Driven Design for coding agents
+const HELP = `businesslens — Product-Driven Development for coding agents
 
 Usage: businesslens <command> [options]
 

--- a/src/commands/build.ts
+++ b/src/commands/build.ts
@@ -127,6 +127,9 @@ export function buildProject(cwd: string): BuildOutcome {
   if (!result.ok) {
     throw new Error(`Validation failed:\n${result.errors.map(error => `- ${error}`).join('\n')}`)
   }
+  if (model.coverage.status === 'draft') {
+    throw new Error('coverage.md status is draft — a planned map cannot be built or published. Implement the planned behavior, verify it with businesslens-verify, and set coverage to partial or complete.')
+  }
   const pinned = provenance(root)
   const today = new Date().toISOString().slice(0, 10)
   const project = compileProject(model, pinned, tracked.length, today)

--- a/src/commands/validate.ts
+++ b/src/commands/validate.ts
@@ -26,6 +26,14 @@ export function validateModel(model: PddModel, trackedFiles: string[]): Validati
     if (!lead) errors.push(`${label}: missing lead paragraph (description)`)
   }
 
+  // A draft map is planned, not yet implemented: missing evidence is a
+  // warning until coverage leaves draft, when it becomes an error again.
+  const draft = model.coverage.status === 'draft'
+  const requireEvidence = (label: string) => {
+    if (draft) warnings.push(`${label}: needs at least one codeRef before coverage can leave draft`)
+    else errors.push(`${label}: needs at least one codeRef`)
+  }
+
   if (model.product.id && !isId(model.product.id)) errors.push('product.md: id must be lowercase kebab-case')
   if (!model.product.id) errors.push('product.md: missing id')
   requireTitle('product.md', model.product.doc.title, model.product.doc.lead)
@@ -81,7 +89,7 @@ export function validateModel(model: PddModel, trackedFiles: string[]): Validati
     for (const experienceId of journey.experiences) {
       if (!experienceIds.has(experienceId)) errors.push(`${label}: references missing experience "${experienceId}"`)
     }
-    if (!journey.codeRefs.length) errors.push(`${label}: needs at least one codeRef`)
+    if (!journey.codeRefs.length) requireEvidence(label)
     if (!journey.scenarios.length) errors.push(`${label}: needs at least one scenario`)
 
     for (const scenario of journey.scenarios) {
@@ -97,7 +105,7 @@ export function validateModel(model: PddModel, trackedFiles: string[]): Validati
       if (!scenario.trigger) errors.push(`${scenarioLabel}: missing "## Trigger" section`)
       if (!scenario.steps.length) errors.push(`${scenarioLabel}: "## Steps" needs at least one ordered item`)
       if (!scenario.outcome) errors.push(`${scenarioLabel}: missing "## Outcome" section`)
-      if (!scenario.codeRefs.length) errors.push(`${scenarioLabel}: needs at least one codeRef`)
+      if (!scenario.codeRefs.length) requireEvidence(scenarioLabel)
     }
   }
 

--- a/src/core/skill-installation.ts
+++ b/src/core/skill-installation.ts
@@ -16,6 +16,8 @@ import { providerSkillsDir } from './providers.js'
 
 export const BUSINESSLENS_SKILLS = [
   'businesslens-init',
+  'businesslens-plan',
+  'businesslens-verify',
   'businesslens-sync',
   'businesslens-deep-dive',
   'businesslens-validate',

--- a/test/e2e.test.ts
+++ b/test/e2e.test.ts
@@ -58,6 +58,26 @@ describe('end to end on a real git repo', () => {
     expect(JSON.stringify(second.project)).toBe(JSON.stringify(first.project))
   })
 
+  it('refuses to build a draft (planned) map', () => {
+    const isolated = mkdtempSync(join(tmpdir(), 'bl-e2e-draft-'))
+    try {
+      cpSync(FIXTURE, isolated, { recursive: true })
+      writeFileSync(
+        join(isolated, '.businesslens/coverage.md'),
+        '---\nstatus: draft\nmethod: ["Planned before implementation"]\nsourceAreas: []\nunmapped: []\nlimitations: []\n---\n\n# Coverage\n\nPlanned map.\n'
+      )
+      sh(isolated, 'git', 'init', '--initial-branch=main')
+      sh(isolated, 'git', 'config', 'user.email', 'fixture@example.com')
+      sh(isolated, 'git', 'config', 'user.name', 'Fixture')
+      sh(isolated, 'git', 'remote', 'add', 'origin', 'https://github.com/example/fixture-shop.git')
+      sh(isolated, 'git', 'add', '.')
+      sh(isolated, 'git', 'commit', '-m', 'fixture')
+      expect(() => buildProject(isolated)).toThrow(/draft/)
+    } finally {
+      rmSync(isolated, { recursive: true, force: true })
+    }
+  })
+
   it('refuses to build with a dirty tracked worktree', () => {
     sh(repo, 'bash', '-c', 'echo "// dirty" >> src/models/order.ts')
     expect(() => buildProject(repo)).toThrow(/uncommitted changes/)

--- a/test/install.test.ts
+++ b/test/install.test.ts
@@ -33,7 +33,7 @@ afterEach(() => {
 })
 
 describe('skill installation', () => {
-  it('installs only the six namespaced skills into every selected project harness', async () => {
+  it('installs only the eight namespaced skills into every selected project harness', async () => {
     const project = temporary('bl-install-')
     vi.spyOn(console, 'log').mockImplementation(() => undefined)
 
@@ -62,6 +62,8 @@ describe('skill installation', () => {
     expect(existsSync(join(project, '.claude', 'commands'))).toBe(false)
     expect(existsSync(join(project, '.claude', 'skills', 'businesslens-init', 'references', 'format.md'))).toBe(true)
     expect(existsSync(join(project, '.claude', 'skills', 'businesslens-init', 'scripts', 'inventory-repository.mjs'))).toBe(true)
+    expect(existsSync(join(project, '.claude', 'skills', 'businesslens-plan', 'scripts', 'run-businesslens.mjs'))).toBe(true)
+    expect(existsSync(join(project, '.claude', 'skills', 'businesslens-verify', 'scripts', 'run-businesslens.mjs'))).toBe(true)
     expect(existsSync(join(project, '.claude', 'skills', 'businesslens-publish', 'scripts', 'run-businesslens.mjs'))).toBe(true)
   })
 

--- a/test/publish-runner.test.ts
+++ b/test/publish-runner.test.ts
@@ -12,7 +12,28 @@ import { tmpdir } from 'node:os'
 import { delimiter, join } from 'node:path'
 import { afterEach, describe, expect, it } from 'vitest'
 
-const RUNNER = join(__dirname, '..', 'skills', 'businesslens-publish', 'scripts', 'run-businesslens.mjs')
+const VALIDATE_RUNNERS = [
+  {
+    name: 'plan',
+    file: join(__dirname, '..', 'skills', 'businesslens-plan', 'scripts', 'run-businesslens.mjs')
+  },
+  {
+    name: 'verify',
+    file: join(__dirname, '..', 'skills', 'businesslens-verify', 'scripts', 'run-businesslens.mjs')
+  },
+  {
+    name: 'publish',
+    file: join(__dirname, '..', 'skills', 'businesslens-publish', 'scripts', 'run-businesslens.mjs')
+  }
+]
+const PUBLISH_RUNNER = join(
+  __dirname,
+  '..',
+  'skills',
+  'businesslens-publish',
+  'scripts',
+  'run-businesslens.mjs'
+)
 const temporaryDirectories: string[] = []
 
 function temporary(prefix: string): string {
@@ -27,8 +48,8 @@ afterEach(() => {
   }
 })
 
-describe.skipIf(process.platform === 'win32')('isolated publish-skill runner', () => {
-  it('runs npm outside the target and scrubs the key during validation', () => {
+describe.skipIf(process.platform === 'win32')('isolated skill runners', () => {
+  it.each(VALIDATE_RUNNERS)('$name runs npm outside the target and scrubs the key during validation', ({ file }) => {
     const repo = temporary('bl-runner-repo-')
     const bin = temporary('bl-runner-bin-')
     const capture = join(temporary('bl-runner-capture-'), 'npm.json')
@@ -55,7 +76,7 @@ fs.writeFileSync(process.env.CAPTURE_FILE, JSON.stringify({
 
     execFileSync(
       process.execPath,
-      [RUNNER, '--root', repo, 'validate', '--json'],
+      [file, '--root', repo, 'validate', '--json'],
       {
         env: {
           ...process.env,
@@ -106,7 +127,7 @@ require('node:fs').writeFileSync(process.env.CAPTURE_FILE, JSON.stringify({
 
     execFileSync(
       process.execPath,
-      [RUNNER, '--root', repo, 'publish', '--yes'],
+      [PUBLISH_RUNNER, '--root', repo, 'publish', '--yes'],
       {
         env: {
           ...process.env,

--- a/test/validate.test.ts
+++ b/test/validate.test.ts
@@ -163,4 +163,69 @@ Lead.
     const result = run(cwd)
     expect(result.errors.some(error => error.includes('unknown frontmatter key "color"'))).toBe(true)
   })
+
+  it('downgrades missing evidence to warnings while coverage status is draft', () => {
+    const cwd = fixtureCopy()
+    writeFileSync(join(cwd, '.businesslens/coverage.md'), `---
+status: draft
+method: ["Planned before implementation"]
+sourceAreas: []
+unmapped: []
+limitations: []
+---
+
+# Coverage
+
+Planned map.
+`)
+    writeFileSync(join(cwd, '.businesslens/journeys/manage-orders/journey.md'), `---
+domain: ordering
+actors: [store-admin]
+experiences: [admin-console]
+---
+
+# Manage orders
+
+An admin reviews and refunds orders.
+`)
+    writeFileSync(join(cwd, '.businesslens/journeys/manage-orders/scenarios/refund-order.md'), `---
+kind: edge
+---
+
+# Refund an order
+
+## Trigger
+
+t.
+
+## Steps
+
+1. s
+
+## Outcome
+
+o.
+`)
+    const result = run(cwd)
+    expect(result.errors).toEqual([])
+    expect(result.ok).toBe(true)
+    expect(result.warnings.filter(warning => warning.includes('needs at least one codeRef'))).toHaveLength(2)
+  })
+
+  it('keeps missing evidence an error once coverage leaves draft', () => {
+    const cwd = fixtureCopy()
+    writeFileSync(join(cwd, '.businesslens/journeys/manage-orders/journey.md'), `---
+domain: ordering
+actors: [store-admin]
+experiences: [admin-console]
+---
+
+# Manage orders
+
+An admin reviews and refunds orders.
+`)
+    const result = run(cwd)
+    expect(result.ok).toBe(false)
+    expect(result.errors.some(error => error.includes('needs at least one codeRef'))).toBe(true)
+  })
 })


### PR DESCRIPTION
## What and why

Adds a product-map-first workflow for greenfield products and planned feature work. BusinessLens can now author a draft map before implementation, verify the complete planned delta afterward, and attach tracked code evidence before merge.

## Highlights

- Adds the businesslens-plan and businesslens-verify skills.
- Supports draft coverage with missing-evidence warnings while blocking build and publish.
- Verifies additions, modifications, removals, and higher-level product contracts.
- Uses isolated validation runners so untrusted target repositories cannot intercept execution.
- Expands and structures the open-source documentation, tutorials, skill pages, and validation reference.
- Enforces valid, globally unique documentation navigation order.
- Uses Product-Driven Development as the expanded form of PDD across CLI, docs, skills, and package metadata.

## Validation

- [x] npm run verify — 53 tests passed
- [x] npm pack --dry-run inspected
- [x] All eight skills passed quick_validate.py
- [x] claude plugin validate . --strict passed
- [x] Documentation frontmatter and relative links passed
- [x] No secrets or private repository URLs in the diff