### PR TITLE
fix: compile the theme lab package export (0.7.1)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "businesslens",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "Product-Driven Development for coding agents: build and maintain a git-tracked Product Model in .businesslens/.",
   "author": {
     "name": "BusinessLens",

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -70,6 +70,11 @@ jobs:
           mkdir -p "$cli_only"
           npm install --prefix "$cli_only" --ignore-scripts "${{ steps.pack.outputs.tarball }}"
           node "$cli_only/node_modules/businesslens/dist/cli.js" --version
+          (
+            cd "$cli_only"
+            node --input-type=module --eval \
+              "import { BUSINESSLENS_DEFAULT_LIGHT_BACKGROUND } from 'businesslens/theme-lab/variants'; if (BUSINESSLENS_DEFAULT_LIGHT_BACKGROUND !== 'l4') process.exit(1)"
+          )
           for ui_dependency in \
             nuxt \
             vue \

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.1] - 2026-08-04
+
+### Fixed
+
+- Compile the public `businesslens/theme-lab/variants` subpath into `dist` so
+  plain Node consumers such as Playwright can import it from `node_modules`
+  without relying on unsupported TypeScript stripping.
+
 ## [0.7.0] - 2026-08-04
 
 ### Added
@@ -246,7 +254,8 @@ Initial public launch of the repository.
   `docs/format.md`.
 - Claude plugin manifest and marketplace entry.
 
-[Unreleased]: https://github.com/businesslens/pdd/compare/v0.7.0...HEAD
+[Unreleased]: https://github.com/businesslens/pdd/compare/v0.7.1...HEAD
+[0.7.1]: https://github.com/businesslens/pdd/compare/v0.7.0...v0.7.1
 [0.7.0]: https://github.com/businesslens/pdd/compare/v0.6.0...v0.7.0
 [0.6.0]: https://github.com/businesslens/pdd/compare/v0.5.0...v0.6.0
 [0.5.0]: https://github.com/businesslens/pdd/compare/v0.4.0...v0.5.0

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "businesslens",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "businesslens",
-      "version": "0.7.0",
+      "version": "0.7.1",
       "license": "MIT",
       "workspaces": [
         "viewer/app"
@@ -14379,7 +14379,7 @@
     },
     "viewer/app": {
       "name": "@businesslens/local-report-viewer",
-      "version": "0.7.0",
+      "version": "0.7.1",
       "dependencies": {
         "@fontsource-variable/archivo": "^5.3.0",
         "@fontsource-variable/inter": "^5.2.8",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "businesslens",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "Product-Driven Development for coding agents: a git-tracked Product Model in .businesslens/, verified against implementation.",
   "type": "module",
   "license": "MIT",
@@ -41,7 +41,10 @@
     "./nuxt/report-viewer": "./layers/nuxt/report-viewer/nuxt.config.ts",
     "./nuxt/theme": "./layers/nuxt/theme/nuxt.config.ts",
     "./nuxt/theme-lab": "./layers/nuxt/theme-lab/nuxt.config.ts",
-    "./theme-lab/variants": "./layers/nuxt/theme-lab/app/utils/businesslensThemeLabVariants.ts",
+    "./theme-lab/variants": {
+      "types": "./dist/businesslensThemeLabVariants.d.ts",
+      "default": "./dist/businesslensThemeLabVariants.js"
+    },
     "./package.json": "./package.json"
   },
   "files": [

--- a/scripts/check-repo.mjs
+++ b/scripts/check-repo.mjs
@@ -77,7 +77,8 @@ if (lock.packages?.['viewer/app']?.version !== pkg.version) {
 if (pkg.exports?.['./nuxt/report-viewer'] !== './layers/nuxt/report-viewer/nuxt.config.ts'
   || pkg.exports?.['./nuxt/theme'] !== './layers/nuxt/theme/nuxt.config.ts'
   || pkg.exports?.['./nuxt/theme-lab'] !== './layers/nuxt/theme-lab/nuxt.config.ts'
-  || pkg.exports?.['./theme-lab/variants'] !== './layers/nuxt/theme-lab/app/utils/businesslensThemeLabVariants.ts'
+  || pkg.exports?.['./theme-lab/variants']?.types !== './dist/businesslensThemeLabVariants.d.ts'
+  || pkg.exports?.['./theme-lab/variants']?.default !== './dist/businesslensThemeLabVariants.js'
   || !pkg.exports?.['./report/view-model']
   || !pkg.exports?.['./logo']) {
   errors.push('businesslens must export its logo contract, report view model, and Nuxt report-viewer/theme/theme-lab Layers')

--- a/test/theme-lab.test.ts
+++ b/test/theme-lab.test.ts
@@ -31,12 +31,6 @@ const iconFiles = [
 ]
 
 describe('shared BusinessLens theme lab', () => {
-  it('exposes compiled variants to plain Node package consumers', async () => {
-    const published = await import('businesslens/theme-lab/variants')
-    expect(published.BUSINESSLENS_DEFAULT_LIGHT_BACKGROUND).toBe('l4')
-    expect(published.BUSINESSLENS_MARK_VARIANTS).toEqual(BUSINESSLENS_MARK_VARIANTS)
-  })
-
   it('keeps the approved starting selections as experimental defaults', () => {
     expect(BUSINESSLENS_LIGHT_BACKGROUNDS.find(item => item.id === BUSINESSLENS_DEFAULT_LIGHT_BACKGROUND)?.name)
       .toBe('Glow')

--- a/test/theme-lab.test.ts
+++ b/test/theme-lab.test.ts
@@ -31,6 +31,12 @@ const iconFiles = [
 ]
 
 describe('shared BusinessLens theme lab', () => {
+  it('exposes compiled variants to plain Node package consumers', async () => {
+    const published = await import('businesslens/theme-lab/variants')
+    expect(published.BUSINESSLENS_DEFAULT_LIGHT_BACKGROUND).toBe('l4')
+    expect(published.BUSINESSLENS_MARK_VARIANTS).toEqual(BUSINESSLENS_MARK_VARIANTS)
+  })
+
   it('keeps the approved starting selections as experimental defaults', () => {
     expect(BUSINESSLENS_LIGHT_BACKGROUNDS.find(item => item.id === BUSINESSLENS_DEFAULT_LIGHT_BACKGROUND)?.name)
       .toBe('Glow')

--- a/tsdown.config.ts
+++ b/tsdown.config.ts
@@ -3,7 +3,14 @@ import { defineConfig } from 'tsdown'
 export default defineConfig({
   // `report` is the published library entry consumed by BusinessLens Platform;
   // it carries type declarations because it is a cross-repository contract.
-  entry: ['src/cli.ts', 'src/report.ts', 'src/report-digest.ts', 'src/report-view-model.ts', 'src/logo.ts'],
+  entry: {
+    cli: 'src/cli.ts',
+    report: 'src/report.ts',
+    'report-digest': 'src/report-digest.ts',
+    'report-view-model': 'src/report-view-model.ts',
+    logo: 'src/logo.ts',
+    businesslensThemeLabVariants: 'layers/nuxt/theme-lab/app/utils/businesslensThemeLabVariants.ts'
+  },
   format: 'esm',
   platform: 'node',
   dts: true,

--- a/viewer/app/package.json
+++ b/viewer/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@businesslens/local-report-viewer",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
The 0.7.0 package exposed the theme-lab variants as TypeScript under node_modules, which plain Node and Playwright refuse to strip. Compile the public subpath into dist, test the self-reference, and add the package artifact import to the OIDC publish smoke test.\n\nPrepared as 0.7.1. Validation: npm run verify (169 tests), npm pack --dry-run, all three skill validators, and Claude plugin validation.\n\nAssisted-by: Codex:GPT-5