### PR TITLE
fix: harden blueprint publishing (0.7.2)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "businesslens",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "description": "Product-Driven Development for coding agents: build and maintain a git-tracked Product Model in .businesslens/.",
   "author": {
     "name": "BusinessLens",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.2] - 2026-08-05
+
+### Added
+
+- Add `--help` and strict option parsing to the Blueprint catalog publisher so
+  its maintainer-only production flow is discoverable before a credential is
+  configured.
+
 ### Fixed
 
 - Open the `BL` ligature apart in the generated tab icons, so a browser tab shows
   two letters instead of one blob at 16px. Only the favicon family is respaced —
   the logo artwork and the larger app icons keep the ligature as drawn.
+- Restrict the Blueprint publisher credential to the exact production catalog
+  origin or a loopback development origin, preventing a mistaken `--catalog`
+  value from sending it to an arbitrary HTTPS host.
 
 ## [0.7.1] - 2026-08-04
 
@@ -260,7 +271,8 @@ Initial public launch of the repository.
   `docs/format.md`.
 - Claude plugin manifest and marketplace entry.
 
-[Unreleased]: https://github.com/businesslens/pdd/compare/v0.7.1...HEAD
+[Unreleased]: https://github.com/businesslens/pdd/compare/v0.7.2...HEAD
+[0.7.2]: https://github.com/businesslens/pdd/compare/v0.7.1...v0.7.2
 [0.7.1]: https://github.com/businesslens/pdd/compare/v0.7.0...v0.7.1
 [0.7.0]: https://github.com/businesslens/pdd/compare/v0.6.0...v0.7.0
 [0.6.0]: https://github.com/businesslens/pdd/compare/v0.5.0...v0.6.0

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "businesslens",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "businesslens",
-      "version": "0.7.1",
+      "version": "0.7.2",
       "license": "MIT",
       "workspaces": [
         "viewer/app"
@@ -14379,7 +14379,7 @@
     },
     "viewer/app": {
       "name": "@businesslens/local-report-viewer",
-      "version": "0.7.1",
+      "version": "0.7.2",
       "dependencies": {
         "@fontsource-variable/archivo": "^5.3.0",
         "@fontsource-variable/inter": "^5.2.8",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "businesslens",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "description": "Product-Driven Development for coding agents: a git-tracked Product Model in .businesslens/, verified against implementation.",
   "type": "module",
   "license": "MIT",

--- a/scripts/blueprints-publish.mjs
+++ b/scripts/blueprints-publish.mjs
@@ -84,9 +84,13 @@ function trustedCatalogOrigin(value) {
   if (url.username || url.password || url.search || url.hash || url.pathname !== '/') {
     fail('The catalog origin must be a bare origin with no credentials, path, query, or fragment.')
   }
-  const loopback = url.hostname === 'localhost' || url.hostname === '::1' || /^127(\.\d+){3}$/.test(url.hostname)
-  if (url.protocol === 'https:' || (loopback && url.protocol === 'http:')) return url.origin
-  fail('The catalog origin must use https, except on a loopback host.')
+  const loopback = url.hostname === 'localhost'
+    || url.hostname === '::1'
+    || url.hostname === '[::1]'
+    || /^127(\.\d+){3}$/.test(url.hostname)
+  if (url.origin === 'https://businesslens.io') return url.origin
+  if (loopback && (url.protocol === 'http:' || url.protocol === 'https:')) return url.origin
+  fail('The publisher catalog must be https://businesslens.io or a loopback origin.')
 }
 
 const catalog = trustedCatalogOrigin(origin)

--- a/scripts/blueprints-publish.mjs
+++ b/scripts/blueprints-publish.mjs
@@ -16,22 +16,58 @@ import { createInterface } from 'node:readline/promises'
 import { lstat, readdir, readFile } from 'node:fs/promises'
 import { existsSync } from 'node:fs'
 import { join, resolve } from 'node:path'
-import { projectPortableReport } from '../dist/report.js'
-import { validateProductLogo } from '../dist/logo.js'
 
 const root = process.cwd()
 const cli = resolve(root, 'dist/cli.js')
 const blueprintsDir = resolve(root, 'blueprints')
 
 const args = process.argv.slice(2)
-const assumeYes = args.includes('--yes')
-const dryRun = args.includes('--dry-run')
-const catalogArg = args.indexOf('--catalog')
-const origin = catalogArg >= 0 ? args[catalogArg + 1] : process.env.BUSINESSLENS_CATALOG_URL ?? 'https://businesslens.io'
 
 function fail(message) {
   console.error(`error: ${message}`)
   process.exit(1)
+}
+
+function showHelp() {
+  console.log(`Usage: npm run blueprints:publish -- [options]
+
+Build and publish every Blueprint under blueprints/ to a catalog. Blueprints
+present in the catalog but absent locally are withdrawn.
+
+Options:
+  --catalog <origin>  Catalog origin (default: BUSINESSLENS_CATALOG_URL or
+                      https://businesslens.io)
+  --dry-run           Build and show the planned changes without catalog writes
+  --yes               Skip the confirmation prompt
+  -h, --help          Show this help
+
+Environment:
+  BUSINESSLENS_CATALOG_KEY  Required bearer credential
+  BUSINESSLENS_CATALOG_URL  Default catalog origin when --catalog is omitted`)
+}
+
+if (args.includes('--help') || args.includes('-h')) {
+  showHelp()
+  process.exit(0)
+}
+
+let assumeYes = false
+let dryRun = false
+let origin = process.env.BUSINESSLENS_CATALOG_URL ?? 'https://businesslens.io'
+for (let index = 0; index < args.length; index += 1) {
+  const arg = args[index]
+  if (arg === '--yes') {
+    assumeYes = true
+  } else if (arg === '--dry-run') {
+    dryRun = true
+  } else if (arg === '--catalog') {
+    const value = args[index + 1]
+    if (!value || value.startsWith('-')) fail('--catalog requires an origin.')
+    origin = value
+    index += 1
+  } else {
+    fail(`Unknown option "${arg}". Run \`npm run blueprints:publish -- --help\` for usage.`)
+  }
 }
 
 /**
@@ -57,6 +93,9 @@ const catalog = trustedCatalogOrigin(origin)
 const isLoopbackCatalog = /^https?:\/\/(localhost|127(\.\d+){3}|\[?::1\]?)(:\d+)?$/.test(catalog)
 const key = process.env.BUSINESSLENS_CATALOG_KEY
 if (!key) fail('BUSINESSLENS_CATALOG_KEY is not set.')
+
+const { projectPortableReport } = await import('../dist/report.js')
+const { validateProductLogo } = await import('../dist/logo.js')
 
 function git(...gitArgs) {
   return execFileSync('git', ['-C', root, ...gitArgs], { encoding: 'utf8' }).trim()

--- a/test/blueprints-publish.test.ts
+++ b/test/blueprints-publish.test.ts
@@ -6,10 +6,10 @@ const ROOT = join(__dirname, '..')
 const SCRIPT = join(ROOT, 'scripts', 'blueprints-publish.mjs')
 const { BUSINESSLENS_CATALOG_KEY: _catalogKey, ...envWithoutKey } = process.env
 
-function publish(...args: string[]) {
+function publishWithEnv(env: NodeJS.ProcessEnv, ...args: string[]) {
   const result = spawnSync(process.execPath, [SCRIPT, ...args], {
     cwd: ROOT,
-    env: envWithoutKey,
+    env,
     encoding: 'utf8'
   })
   return {
@@ -17,6 +17,10 @@ function publish(...args: string[]) {
     stdout: result.stdout ?? '',
     stderr: result.stderr ?? ''
   }
+}
+
+function publish(...args: string[]) {
+  return publishWithEnv(envWithoutKey, ...args)
 }
 
 describe('Blueprint publishing script', () => {
@@ -47,5 +51,37 @@ describe('Blueprint publishing script', () => {
     expect(result.status).toBe(1)
     expect(result.stderr).toContain('--catalog requires an origin')
     expect(result.stderr).not.toContain('BUSINESSLENS_CATALOG_KEY is not set')
+  })
+
+  it('rejects arbitrary HTTPS origins before a publisher key can be sent', () => {
+    for (const origin of [
+      'https://attacker.invalid',
+      'https://businesslens.io.attacker.invalid',
+      'https://www.businesslens.io'
+    ]) {
+      const result = publishWithEnv(
+        { ...envWithoutKey, BUSINESSLENS_CATALOG_KEY: 'must-not-leave-this-process' },
+        '--catalog',
+        origin,
+        '--dry-run'
+      )
+      expect(result.status).toBe(1)
+      expect(result.stderr).toContain('must be https://businesslens.io or a loopback origin')
+      expect(result.stderr).not.toContain('Could not read the live catalog')
+    }
+  })
+
+  it('accepts the production catalog and loopback development origins', () => {
+    for (const origin of [
+      'https://businesslens.io',
+      'http://localhost:3200',
+      'http://127.0.0.1:3200',
+      'https://[::1]:3200'
+    ]) {
+      const result = publish('--catalog', origin, '--dry-run')
+      expect(result.status).toBe(1)
+      expect(result.stderr).toContain('BUSINESSLENS_CATALOG_KEY is not set')
+      expect(result.stderr).not.toContain('publisher catalog must be')
+    }
   })
 })

--- a/test/blueprints-publish.test.ts
+++ b/test/blueprints-publish.test.ts
@@ -1,0 +1,51 @@
+import { spawnSync } from 'node:child_process'
+import { join } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+const ROOT = join(__dirname, '..')
+const SCRIPT = join(ROOT, 'scripts', 'blueprints-publish.mjs')
+const { BUSINESSLENS_CATALOG_KEY: _catalogKey, ...envWithoutKey } = process.env
+
+function publish(...args: string[]) {
+  const result = spawnSync(process.execPath, [SCRIPT, ...args], {
+    cwd: ROOT,
+    env: envWithoutKey,
+    encoding: 'utf8'
+  })
+  return {
+    status: result.status ?? 1,
+    stdout: result.stdout ?? '',
+    stderr: result.stderr ?? ''
+  }
+}
+
+describe('Blueprint publishing script', () => {
+  it('shows its options with --help and -h without requiring a catalog key', () => {
+    for (const option of ['--help', '-h']) {
+      const result = publish(option)
+      expect(result.status).toBe(0)
+      expect(result.stderr).toBe('')
+      expect(result.stdout).toContain('Usage: npm run blueprints:publish -- [options]')
+      expect(result.stdout).toContain('--catalog <origin>')
+      expect(result.stdout).toContain('--dry-run')
+      expect(result.stdout).toContain('--yes')
+      expect(result.stdout).toContain('BUSINESSLENS_CATALOG_KEY')
+      expect(result.stdout).toContain('BUSINESSLENS_CATALOG_URL')
+      expect(result.stdout).toContain('absent locally are withdrawn')
+    }
+  })
+
+  it('rejects unknown options with a pointer to help', () => {
+    const result = publish('--wat')
+    expect(result.status).toBe(1)
+    expect(result.stderr).toContain('Unknown option "--wat"')
+    expect(result.stderr).toContain('npm run blueprints:publish -- --help')
+  })
+
+  it('reports a missing catalog origin before requiring the key', () => {
+    const result = publish('--catalog')
+    expect(result.status).toBe(1)
+    expect(result.stderr).toContain('--catalog requires an origin')
+    expect(result.stderr).not.toContain('BUSINESSLENS_CATALOG_KEY is not set')
+  })
+})

--- a/viewer/app/package.json
+++ b/viewer/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@businesslens/local-report-viewer",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## Summary

- publish the favicon spacing fix as BusinessLens 0.7.2
- add discoverable help and strict publisher option parsing
- restrict the publisher credential to businesslens.io and loopback origins
- cover the credential-origin boundary with regression tests

## Verification

- npm run verify
- npm pack --dry-run