### PR TITLE
fix(pull): advertise the current report media version

### DIFF
--- a/src/commands/pull.ts
+++ b/src/commands/pull.ts
@@ -1,12 +1,14 @@
 import { parseCanonicalName } from '../core/canonical-name.js'
 import { resolveCatalogUrl } from '../core/catalog-url.js'
 import { reportDigest } from '../core/report-digest.js'
+import { REPORT_SCHEMA_VERSION } from '../core/portable.js'
 import { cliVersion } from '../version.js'
 import { expandProductReport } from './open.js'
 import { UsageError } from '../core/usage-error.js'
 import { MAX_PRODUCT_LOGO_BYTES, validateProductLogo } from '../logo.js'
 
 const MAX_REPORT_BYTES = 8 * 1024 * 1024
+const REPORT_MEDIA_TYPE_VERSION = REPORT_SCHEMA_VERSION.split('.')[0]
 
 export interface PullOptions {
   catalog?: string
@@ -119,7 +121,7 @@ export async function runPull(
   try {
     response = await fetch(url, {
       headers: {
-        accept: 'application/vnd.businesslens.report+json; version=7, application/json',
+        accept: `application/vnd.businesslens.report+json; version=${REPORT_MEDIA_TYPE_VERSION}, application/json`,
         // Identify the CLI so catalog pulls are distinguishable from browser
         // fetches. Without it every pull is indistinguishable from a page view.
         'user-agent': `businesslens/${cliVersion()}`

--- a/test/pull.test.ts
+++ b/test/pull.test.ts
@@ -32,7 +32,7 @@ function reportResponse(canonicalName = 'fixture-shop'): Response {
   return new Response(JSON.stringify(report), {
     status: 200,
     headers: {
-      'content-type': 'application/vnd.businesslens.report+json; version=7',
+      'content-type': 'application/vnd.businesslens.report+json; version=8',
       'x-businesslens-blueprint': canonicalName,
       'x-businesslens-report-digest': reportDigest(report)
     }
@@ -83,7 +83,7 @@ describe('pull', () => {
     )
     // No credential is read, sent, or required.
     expect((requested?.init.headers as Record<string, string>).authorization).toBeUndefined()
-    expect((requested?.init.headers as Record<string, string>).accept).toContain('version=7')
+    expect((requested?.init.headers as Record<string, string>).accept).toContain('version=8')
     expect(existsSync(join(target, '.businesslens/product.md'))).toBe(true)
     expect(existsSync(join(target, '.businesslens/screens/product-record.md'))).toBe(true)
     expect(readFileSync(join(target, '.businesslens/logo.svg'))).toEqual(logo)


### PR DESCRIPTION
## Summary

- derive the catalog Accept vendor version from REPORT_SCHEMA_VERSION
- update pull contract coverage for Product Report v8
- intentionally drop the stale v7 advertisement as part of the coordinated migration

## Coordination

Companion to businesslens/landing#42 for businesslens/landing#24.

## Verification

- npm run verify
- 23 test files and 195 tests passed