### PR TITLE
fix: align release smoke with retired report export

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -103,7 +103,11 @@ jobs:
           tar -tzf "${{ steps.pack.outputs.tarball }}" | grep '^package/layers/nuxt/theme/nuxt.config.ts$' >/dev/null
           tar -tzf "${{ steps.pack.outputs.tarball }}" | grep '^package/layers/nuxt/theme-lab/nuxt.config.ts$' >/dev/null
           tar -tzf "${{ steps.pack.outputs.tarball }}" | grep '^package/layers/nuxt/theme-lab/public/brand/logo/variants/mark-10.svg$' >/dev/null
-          tar -tzf "${{ steps.pack.outputs.tarball }}" | grep '^package/dist/report-view-model.js$' >/dev/null
+          if tar -tzf "${{ steps.pack.outputs.tarball }}" \
+            | grep '^package/dist/report-view-model.js$' >/dev/null; then
+            echo 'Retired report view-model export must not be packaged.' >&2
+            exit 1
+          fi
           tar -tzf "${{ steps.pack.outputs.tarball }}" | grep '^package/dist/logo.js$' >/dev/null
 
           nuxt_smoke="$smoke_root/nuxt-layer-consumer"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -251,6 +251,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- The release artifact smoke test now rejects the retired lossy Report View
+  Model export instead of requiring it. The export was deliberately removed
+  when the complete Product Report became the sole renderer input, but the
+  stale positive assertion stopped the first `v0.8.0` publish before npm.
 - `package.json` no longer lists `plans/shared-theme-lab.md` among its packaged
   files. The file was deleted while the entry stayed, and npm drops a missing
   `files` entry silently, so the packed tarball simply carried no `plans/` at


### PR DESCRIPTION
## Summary

- invert the stale tarball assertion for `dist/report-view-model.js`
- keep the retired lossy view-model export absent, matching package exports and repository checks
- record the stopped first 0.8.0 publish in the existing 0.8.0 changelog entry

## Why

The 0.8.0 release workflow verified and tagged the merge commit, then stopped before npm publication because its artifact smoke test still required a file deliberately removed when the complete Product Report became the renderer input.

No `businesslens@0.8.0` package was published. After this PR merges, the failed tag can be removed and the idempotent release workflow rerun against corrected `main`.

## Verification

- `npm run verify` — 23 test files / 256 tests
- `npm pack --dry-run --json --ignore-scripts` — 245 entries
- whitespace checks passed
