### PR TITLE
fix: follow the promoted theme in release smoke

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -102,7 +102,7 @@ jobs:
           tar -tzf "${{ steps.pack.outputs.tarball }}" | grep '^package/layers/nuxt/report-viewer/nuxt.config.ts$' >/dev/null
           tar -tzf "${{ steps.pack.outputs.tarball }}" | grep '^package/layers/nuxt/theme/nuxt.config.ts$' >/dev/null
           tar -tzf "${{ steps.pack.outputs.tarball }}" | grep '^package/layers/nuxt/theme-lab/nuxt.config.ts$' >/dev/null
-          tar -tzf "${{ steps.pack.outputs.tarball }}" | grep '^package/layers/nuxt/theme-lab/public/brand/logo/variants/mark-10.svg$' >/dev/null
+          tar -tzf "${{ steps.pack.outputs.tarball }}" | grep '^package/layers/nuxt/theme/public/brand/icons/favicon.svg$' >/dev/null
           if tar -tzf "${{ steps.pack.outputs.tarball }}" \
             | grep '^package/dist/report-view-model.js$' >/dev/null; then
             echo 'Retired report view-model export must not be packaged.' >&2
@@ -160,7 +160,7 @@ jobs:
             | grep '"id":"fixture-shop"' >/dev/null
           curl --fail --silent "$viewer_url/_businesslens/logo.svg" \
             | grep '<svg' >/dev/null
-          curl --fail --silent "$viewer_url/brand/icons/marks/m10/favicon.svg" \
+          curl --fail --silent "$viewer_url/brand/icons/favicon.svg" \
             | grep '<svg' >/dev/null
           test ! -e "$view_project/.businesslens/build/report.json"
           kill -TERM "$viewer_pid"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -251,10 +251,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- The release artifact smoke test now rejects the retired lossy Report View
-  Model export instead of requiring it. The export was deliberately removed
-  when the complete Product Report became the sole renderer input, but the
-  stale positive assertion stopped the first `v0.8.0` publish before npm.
+- The release artifact smoke test follows the promoted stable boundaries: it
+  requires the approved icon under `theme`, not an old `theme-lab` audition
+  path, and rejects the retired lossy Report View Model export instead of
+  requiring it. The stale assertions stopped the first `v0.8.0` publish
+  attempts before npm.
 - `package.json` no longer lists `plans/shared-theme-lab.md` among its packaged
   files. The file was deleted while the entry stayed, and npm drops a missing
   `files` entry silently, so the packed tarball simply carried no `plans/` at


### PR DESCRIPTION
## Summary

- require the approved stable theme favicon in the packed artifact instead of a removed theme-lab audition asset
- request that same stable favicon from the packed local viewer
- correct the 0.8.0 changelog note to cover both stale release assertions

## Verification

- full packed-artifact smoke passed locally, including npm and pnpm Nuxt consumers plus the running local viewer
- `npm run verify` — 23 test files / 256 tests
- package contains 245 entries
- whitespace checks passed

The prior publish attempts stopped before npm. After this PR merges, the unpublished `v0.8.0` tag can be replaced one final time and the corrected release rerun.
