### PR TITLE
refactor: remove retired CLI aliases and installer migrations

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "businesslens",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "description": "Product-Driven Development for coding agents: build and maintain a git-tracked Product Model in .businesslens/.",
   "author": {
     "name": "BusinessLens",

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -24,8 +24,8 @@ body:
     validations:
       required: true
   - type: textarea
-    id: validate-output
+    id: lint-output
     attributes:
-      label: Validate output (optional)
-      description: Output of `npx businesslens validate` if relevant. Redact anything private.
+      label: Lint output (optional)
+      description: Output of `npx businesslens lint` if relevant. Redact anything private.
       render: shell

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -63,7 +63,7 @@ jobs:
             | grep 'view \[options\]' >/dev/null
           npx --yes --package "${{ steps.pack.outputs.tarball }}" businesslens install \
             --providers claude,codex \
-            --project \
+            --scope project \
             --yes
 
           cli_only="$smoke_root/cli-only"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,9 +25,10 @@ were costed and then chosen against, so the same argument is not had twice.
 
 - `src/cli.ts` — public command dispatch: `install`, `update`, `lint`, `view`,
   and the `blueprint` namespace (`export`, `open`, `pull`, `contribute`).
-  Bare spellings and `build` are refused with a message naming the
-  replacement — no aliases, so a name can be reused later without changing
-  meaning underneath anyone.
+  Only documented commands and options are accepted. Removed spellings use
+  normal usage errors; there are no hidden migration commands or scope aliases.
+  Before launch, publication or installation alone does not require historical
+  behavior. Coordinate current producer and consumer changes together.
 - `src/commands/` — public command implementations.
 - `src/core/providers.ts` — supported harness paths and detection.
 - `src/core/skill-installation.ts` — ownership-safe skill installation.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.13.0] - 2026-09-12
+
 ### Removed
 
 - Hidden historical CLI options and command migration messages. Use the commands

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Removed
+
+- Hidden historical CLI options and command migration messages. Use the commands
+  and options shown in help, including `--cwd` and `--scope project|global`.
+- One-off cleanup of old bare-name skills and Claude commands during installation.
+
 ## [0.12.0] - 2026-09-10
 
 ### Changed

--- a/docs/cli-install.md
+++ b/docs/cli-install.md
@@ -59,7 +59,8 @@ install by another tool, or an installation predating the marker — and it stop
 the run unless `--force` is explicit. BusinessLens does not read a directory's
 contents to guess that it wrote it: guessing wrong costs someone work they
 cannot recover. For the same reason, a skill this release no longer ships is
-removed only where the marker recorded it.
+removed only where the marker recorded a `businesslens-*` name. Bare-name skills
+and command files are outside the current installer contract.
 
 **A refusal changes nothing.** Every selected harness is checked before any is
 written, so an install for two harnesses that stops on the second leaves the

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -26,6 +26,8 @@ npx businesslens <command> [options]
 | [`blueprint contribute`](./cli-contribute.md) | Propose a Blueprint by pull request |
 
 Global options are `-c, --cwd <path>`, `-h, --help`, and `-V, --version`.
+Only documented commands and options are accepted; removed spellings produce
+normal usage errors. Installation scope uses `--scope project|global`.
 Each command's help lists only the arguments and options that command accepts:
 
 ```bash

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "businesslens",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "businesslens",
-      "version": "0.12.0",
+      "version": "0.13.0",
       "license": "MIT",
       "workspaces": [
         "viewer/app"
@@ -14595,7 +14595,7 @@
     },
     "viewer/app": {
       "name": "@businesslens/local-report-viewer",
-      "version": "0.12.0",
+      "version": "0.13.0",
       "dependencies": {
         "@fontsource-variable/archivo": "^5.3.0",
         "@fontsource-variable/inter": "^5.2.8",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "businesslens",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "description": "Product-Driven Development for coding agents: a git-tracked Product Model in .businesslens/, verified against implementation.",
   "type": "module",
   "license": "MIT",

--- a/scripts/check-repo.mjs
+++ b/scripts/check-repo.mjs
@@ -321,7 +321,7 @@ if (!modelReadmeMatch) {
 
 // Docs frontmatter contract, consumed by the landing repository's nav:
 // section = top-level tab, group = sidebar cluster, order = global within section.
-const DOC_SECTIONS = new Set(['open-source', 'platform'])
+const DOC_SECTIONS = new Set(['open-source'])
 const DOC_GROUPS = new Set([
   'Get started',
   'Product Model',

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 import { resolve } from 'node:path'
-import { Command, CommanderError, Help, InvalidArgumentError, Option } from 'commander'
+import { Command, CommanderError, Help, InvalidArgumentError } from 'commander'
 import { runContribute } from './commands/contribute.js'
 import { runExport } from './commands/export.js'
 import { runInstall } from './commands/install.js'
@@ -14,9 +14,6 @@ import { cliVersion } from './version.js'
 interface InstallCliOptions {
   providers?: string
   scope?: string
-  project?: boolean
-  global?: boolean
-  user?: boolean
   yes?: boolean
   force?: boolean
 }
@@ -24,9 +21,6 @@ interface InstallCliOptions {
 interface UpdateCliOptions {
   providers?: string
   scope?: string
-  project?: boolean
-  global?: boolean
-  user?: boolean
   force?: boolean
 }
 
@@ -52,8 +46,8 @@ interface ContributeCliOptions {
 }
 
 function cwdFor(command: Command): string {
-  const { cwd, C: legacyCwd } = command.optsWithGlobals() as { cwd?: string; C?: string }
-  return resolve(process.cwd(), cwd || legacyCwd || '.')
+  const { cwd } = command.optsWithGlobals() as { cwd?: string }
+  return resolve(process.cwd(), cwd || '.')
 }
 
 function scope(value: string): 'project' | 'global' {
@@ -75,23 +69,6 @@ function port(value: string): number {
   return parsed
 }
 
-function legacyScopeOptions(command: Command): Command {
-  return command
-    .addOption(new Option('--project').hideHelp())
-    .addOption(new Option('--global').hideHelp())
-    .addOption(new Option('--user').hideHelp())
-}
-
-function retiredCommand(program: Command, name: string, replacement: string): void {
-  program
-    .command(`${name} [arguments...]`, { hidden: true })
-    .allowUnknownOption(true)
-    .description(`Use businesslens ${replacement}`)
-    .action((_arguments: string[], _options: Record<string, never>, command: Command) => {
-      command.error(`error: \`businesslens ${name}\` has moved. Use \`businesslens ${replacement}\`.`)
-    })
-}
-
 function commandsBeforeOptions(output: string): string {
   const trailingNewline = output.endsWith('\n') ? '\n' : ''
   const sections = output.trimEnd().split(/\n{2,}/)
@@ -110,7 +87,6 @@ function createProgram(setExitCode: (code: number) => void): Command {
     .description('Product-Driven Development for coding agents')
     .usage('<command> [options]')
     .option('-c, --cwd <path>', 'Run from another directory')
-    .addOption(new Option('-C <path>').hideHelp().conflicts('cwd'))
     .version(cliVersion(), '-V, --version', 'Show the CLI version')
     .helpOption('-h, --help', 'Show help for command')
     .helpCommand('help [command]', 'Show help for command')
@@ -124,25 +100,25 @@ function createProgram(setExitCode: (code: number) => void): Command {
     })
     .exitOverride()
 
-  legacyScopeOptions(program
+  program
     .command('install')
     .summary('Install BusinessLens skills')
     .description('Install BusinessLens skills for detected AI harnesses.')
     .option('--providers <list>', 'Comma-separated providers: claude,codex,cursor,gemini,github')
     .option('--scope <scope>', 'Installation scope: project or global', scope)
     .option('--yes', 'Accept detected providers and default to project scope')
-    .option('--force', 'Replace an unmarked colliding BusinessLens skill directory'))
+    .option('--force', 'Replace an unmarked colliding BusinessLens skill directory')
     .action(async (options: InstallCliOptions, command: Command) => {
       setExitCode(await runInstall(cwdFor(command), options))
     })
 
-  legacyScopeOptions(program
+  program
     .command('update')
     .summary('Update managed skill installations')
     .description('Update BusinessLens-managed skill installations.')
     .option('--providers <list>', 'Limit discovery to: claude,codex,cursor,gemini,github')
     .option('--scope <scope>', 'Installation scope: project or global', scope)
-    .option('--force', 'Replace an unmarked collision inside a managed installation'))
+    .option('--force', 'Replace an unmarked collision inside a managed installation')
     .action(async (options: UpdateCliOptions, command: Command) => {
       setExitCode(await runUpdate(cwdFor(command), options))
     })
@@ -216,18 +192,6 @@ function createProgram(setExitCode: (code: number) => void): Command {
     .option('--yes', 'Skip the confirmation prompt')
     .action(async (options: ContributeCliOptions, command: Command) => {
       setExitCode(await runContribute(cwdFor(command), { yes: Boolean(options.yes) }))
-    })
-
-  for (const name of ['export', 'open', 'pull', 'contribute']) {
-    retiredCommand(program, name, `blueprint ${name}`)
-  }
-  retiredCommand(program, 'build', 'blueprint export')
-
-  program
-    .command('validate [arguments...]', { hidden: true })
-    .allowUnknownOption(true)
-    .action((_arguments: string[], _options: Record<string, never>, command: Command) => {
-      command.error('error: `businesslens validate` has been renamed. Use `businesslens lint`.')
     })
 
   return program

--- a/src/commands/install.ts
+++ b/src/commands/install.ts
@@ -26,9 +26,6 @@ import { UsageError } from '../core/usage-error.js'
 export interface InstallOptions {
   providers?: string
   scope?: string
-  project?: boolean
-  global?: boolean
-  user?: boolean
   yes?: boolean
   force?: boolean
 }
@@ -38,22 +35,11 @@ function canPrompt(options: InstallOptions): boolean {
 }
 
 function resolveScope(options: InstallOptions): InstallScope | undefined {
-  const aliases = [
-    options.project ? 'project' : undefined,
-    options.global || options.user ? 'global' : undefined
-  ].filter(Boolean)
-  if (aliases.length > 1) throw new UsageError('Choose only one of --project, --global, or --user.')
-
-  const explicit = options.scope?.trim().toLowerCase()
-  if (explicit && explicit !== 'project' && explicit !== 'global' && explicit !== 'user') {
+  const scope = options.scope?.trim().toLowerCase()
+  if (scope && scope !== 'project' && scope !== 'global') {
     throw new UsageError('--scope must be project or global.')
   }
-  const normalized = explicit === 'user' ? 'global' : explicit
-  const alias = aliases[0]
-  if (normalized && alias && normalized !== alias) {
-    throw new UsageError('--scope conflicts with the selected scope flag.')
-  }
-  return (normalized || alias) as InstallScope | undefined
+  return scope as InstallScope | undefined
 }
 
 function printDetected(cwd: string): ReturnType<typeof detectProviders> {
@@ -179,14 +165,6 @@ export async function runInstall(cwd: string, options: InstallOptions = {}): Pro
     )
     console.log(`Installed BusinessLens into: ${roots.join(', ')} (${scope}).`)
     console.log(`Installed skills: ${BUSINESSLENS_SKILLS.join(', ')}.`)
-    const removed = results.flatMap(result => result.removedLegacySkills)
-    if (removed.length > 0) {
-      console.log(`Removed retired BusinessLens skills: ${[...new Set(removed)].join(', ')}.`)
-    }
-    const removedCommands = results.flatMap(result => result.removedLegacyCommands)
-    if (removedCommands.length > 0) {
-      console.log(`Removed retired BusinessLens commands: ${[...new Set(removedCommands)].join(', ')}.`)
-    }
     return 0
   } catch (error) {
     console.error((error as Error).message)

--- a/src/commands/update.ts
+++ b/src/commands/update.ts
@@ -17,30 +17,13 @@ import { UsageError } from '../core/usage-error.js'
 export interface UpdateOptions {
   providers?: string
   scope?: string
-  project?: boolean
-  global?: boolean
-  user?: boolean
   force?: boolean
 }
 
 function resolveScopes(options: UpdateOptions): InstallScope[] {
-  const aliases = [
-    options.project ? 'project' : undefined,
-    options.global || options.user ? 'global' : undefined
-  ].filter(Boolean)
-  if (aliases.length > 1) throw new UsageError('Choose only one of --project, --global, or --user.')
-
-  if (!options.scope && aliases.length === 0) return ['project', 'global']
-  const normalized = options.scope?.trim().toLowerCase()
-  if (normalized && normalized !== 'project' && normalized !== 'global' && normalized !== 'user') {
-    throw new UsageError('--scope must be project or global.')
-  }
-  const scope = normalized === 'user' ? 'global' : normalized
-  if (scope && aliases[0] && scope !== aliases[0]) {
-    throw new UsageError('--scope conflicts with the selected scope flag.')
-  }
-  if ((scope || aliases[0]) === 'project') return ['project']
-  if ((scope || aliases[0]) === 'global') return ['global']
+  const scope = options.scope?.trim().toLowerCase()
+  if (!scope) return ['project', 'global']
+  if (scope === 'project' || scope === 'global') return [scope]
   throw new UsageError('--scope must be project or global.')
 }
 

--- a/src/core/skill-installation.ts
+++ b/src/core/skill-installation.ts
@@ -9,7 +9,7 @@ import {
   rmSync,
   writeFileSync
 } from 'node:fs'
-import { dirname, join, relative, resolve } from 'node:path'
+import { dirname, join, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import type { InstallScope, Provider } from './providers.js'
 import { providerSkillsDir } from './providers.js'
@@ -23,32 +23,6 @@ export const BUSINESSLENS_SKILLS = [
 export type BusinessLensSkill = (typeof BUSINESSLENS_SKILLS)[number]
 
 const MANIFEST_FILE = '.businesslens-install.json'
-const LEGACY_SKILLS = [
-  // Retired in favor of map, ideate, and the verification-owned resolution
-  // loop. Contribution remains a deterministic CLI workflow.
-  'businesslens-init',
-  'businesslens-sync',
-  'businesslens-deep-dive',
-  'businesslens-doctor',
-  'businesslens-contribute',
-  'businesslens-implement',
-  'businesslens-validate',
-  // Folded into `businesslens-ideate`: deciding what to build and writing that
-  // decision into the model are one converging conversation, not two skills.
-  'businesslens-plan',
-  // Renamed in 0.6.0: the catalog's push action is `publish`, so the skill that
-  // proposes a Blueprint by pull request is `contribute`.
-  'businesslens-publish',
-  'map',
-  'sync',
-  'deep-dive',
-  'publish',
-  'analyze-repo',
-  'validate-report',
-  'submit-report',
-  'push-report'
-]
-
 export interface InstallationManifest {
   schema: 1
   package: 'businesslens'
@@ -76,8 +50,6 @@ export interface InstallResult {
   provider: Provider
   scope: InstallScope
   skillsDir: string
-  removedLegacySkills: string[]
-  removedLegacyCommands: string[]
 }
 
 export function bundledSkillsDir(): string | undefined {
@@ -105,12 +77,6 @@ const SKILL_DIRECTORY_NAME = /^[a-z0-9]+(?:-[a-z0-9]+)*$/
 
 function isSkillDirectoryName(name: unknown): name is string {
   return typeof name === 'string' && SKILL_DIRECTORY_NAME.test(name)
-}
-
-/* Only a name this Product could have written is removable: the namespaced
-   skills it ships and the retired bare names it once shipped. */
-function isBusinessLensSkillName(name: string): boolean {
-  return name.startsWith('businesslens-') || LEGACY_SKILLS.includes(name)
 }
 
 /* Belt and braces beside the name check: a path handed to a removal must still
@@ -178,42 +144,6 @@ export function assertInstallTargets(
   }
 }
 
-/* A retired skill is removed only when the manifest says BusinessLens installed
-   it. One that is merely named like a retired skill is left alone. */
-function removeLegacySkills(skillsDir: string, existing: InstallationManifest | undefined): string[] {
-  const removed: string[] = []
-  for (const name of LEGACY_SKILLS) {
-    const target = ownedChildPath(skillsDir, name)
-    if (target === undefined) continue
-    if (!existsSync(target) || !existing?.skills.includes(name)) continue
-    rmSync(target, { recursive: true, force: true })
-    removed.push(name)
-  }
-  return removed
-}
-
-function removeLegacyCommands(cwd: string, target: InstallTarget): string[] {
-  if (target.scope !== 'project' || target.provider.id !== 'claude') return []
-
-  const project = resolve(cwd)
-  const commandFile = join(project, '.claude', 'commands', 'businesslens', 'init.md')
-  if (!existsSync(commandFile)) return []
-
-  try {
-    const source = readFileSync(commandFile, 'utf8')
-    if (!source.includes('BusinessLens') && !source.includes('.businesslens/')) return []
-  } catch {
-    return []
-  }
-
-  rmSync(commandFile, { force: true })
-  const commandDirectory = dirname(commandFile)
-  if (readdirSync(commandDirectory).length === 0) {
-    rmSync(commandDirectory, { recursive: true })
-  }
-  return [relative(project, commandFile)]
-}
-
 function writeManifest(skillsDir: string, manifest: InstallationManifest): void {
   const file = join(skillsDir, MANIFEST_FILE)
   const temporary = `${file}.${randomUUID()}.tmp`
@@ -268,18 +198,14 @@ export function installSkillsToTarget(
   // nobody.
   const staleSkills = (existing?.skills ?? [])
     .filter(previous => !BUSINESSLENS_SKILLS.includes(previous as BusinessLensSkill))
-    .filter(isBusinessLensSkillName)
+    .filter(name => name.startsWith('businesslens-'))
     .map(previous => ownedChildPath(skillsDir, previous))
     .filter((stale): stale is string => stale !== undefined && existsSync(stale))
 
   for (const name of BUSINESSLENS_SKILLS) installSkill(sourceRoot, skillsDir, name)
-  // Retired names first, so the report can say which retired skills went; any
-  // other skill the manifest recorded and this version no longer ships follows.
-  const removedLegacySkills = removeLegacySkills(skillsDir, existing)
   for (const stale of staleSkills) {
     if (existsSync(stale)) rmSync(stale, { recursive: true, force: true })
   }
-  const removedLegacyCommands = removeLegacyCommands(cwd, target)
 
   const now = new Date().toISOString()
   writeManifest(skillsDir, {
@@ -293,7 +219,7 @@ export function installSkillsToTarget(
     updatedAt: now
   })
 
-  return { ...target, skillsDir, removedLegacySkills, removedLegacyCommands }
+  return { ...target, skillsDir }
 }
 
 export function findManagedInstallations(

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -105,7 +105,7 @@ describe('cli help', () => {
     expect(pull.stdout).not.toContain('--providers')
   })
 
-  it('keeps legacy scope shortcuts out of install help', () => {
+  it('lists only the current scope option in install help', () => {
     const result = cli(repo, process.env, 'install', '--help')
     expect(result.status).toBe(0)
     expect(result.stdout).toContain('--scope <scope>')
@@ -130,13 +130,12 @@ describe('cli dispatch', () => {
     expect(output.branch).toBeUndefined()
   })
 
-  it('accepts --cwd and -c before or after a command, plus legacy -C', () => {
+  it('accepts --cwd and -c before or after a command', () => {
     for (const args of [
       ['--cwd', repo, 'lint', '--json'],
       ['lint', '--cwd', repo, '--json'],
       ['-c', repo, 'lint', '--json'],
-      ['lint', '-c', repo, '--json'],
-      ['-C', repo, 'lint', '--json']
+      ['lint', '-c', repo, '--json']
     ]) {
       const result = cli(ROOT, process.env, ...args)
       expect(result.status, args.join(' ')).toBe(0)
@@ -168,22 +167,25 @@ describe('cli dispatch', () => {
     expect(existsSync(join(repo, '.businesslens', 'build', 'report.json'))).toBe(true)
   })
 
-  it('refuses retired command spellings and names their replacements', () => {
-    for (const command of ['export', 'open', 'pull', 'contribute']) {
+  it('refuses removed commands and options as ordinary usage errors', () => {
+    for (const command of ['export', 'open', 'pull', 'contribute', 'build', 'validate']) {
       const result = cli(ROOT, process.env, '--cwd', repo, command)
       expect(result.status, command).toBe(2)
-      expect(result.stderr, command).toContain(
-        `\`businesslens ${command}\` has moved. Use \`businesslens blueprint ${command}\`.`
-      )
+      expect(result.stderr, command).toContain(`unknown command '${command}'`)
     }
-
-    const build = cli(ROOT, process.env, '--cwd', repo, 'build')
-    expect(build.status).toBe(2)
-    expect(build.stderr).toContain('Use `businesslens blueprint export`')
-
-    const validate = cli(ROOT, process.env, '--cwd', repo, 'validate')
-    expect(validate.status).toBe(2)
-    expect(validate.stderr).toContain('Use `businesslens lint`')
+    for (const command of ['install', 'update']) {
+      for (const option of ['--project', '--global', '--user']) {
+        const result = cli(repo, process.env, command, option)
+        expect(result.status, `${command} ${option}`).toBe(2)
+        expect(result.stderr).toContain(`unknown option '${option}'`)
+      }
+      const scope = cli(repo, process.env, command, '--scope', 'user')
+      expect(scope.status).toBe(2)
+      expect(scope.stderr).toContain('expected "project" or "global"')
+    }
+    const cwd = cli(ROOT, process.env, '-C', repo, 'lint')
+    expect(cwd.status).toBe(2)
+    expect(cwd.stderr).toContain("unknown option '-C'")
   })
 
   it('shows Blueprint help without running anything when the group is bare', () => {

--- a/test/install.test.ts
+++ b/test/install.test.ts
@@ -211,64 +211,36 @@ describe('skill installation', () => {
     expect(() => assertInstallTargets(project, targets, { force: true })).not.toThrow()
   })
 
-  it('removes retired skills only when the manifest says BusinessLens installed them', () => {
-    const project = temporary('bl-legacy-')
+  it('removes stale owned namespaced skills and leaves unowned files alone', () => {
+    const project = temporary('bl-owned-skills-')
     const skillsDir = join(project, '.agents', 'skills')
-    const oldMap = join(skillsDir, 'map')
-    const oldPlan = join(skillsDir, 'businesslens-plan')
-    const retiredSync = join(skillsDir, 'businesslens-sync')
-    const lookalike = join(skillsDir, 'businesslens-implement')
-    const unrelatedSync = join(skillsDir, 'sync')
-    for (const directory of [oldMap, oldPlan, retiredSync, lookalike, unrelatedSync]) mkdirSync(directory, { recursive: true })
-    writeFileSync(join(oldMap, 'SKILL.md'), '---\nname: map\n---\nBuild a BusinessLens .businesslens/ Product Model.\n')
-    writeFileSync(join(oldPlan, 'SKILL.md'), '---\nname: businesslens-plan\n---\nPlan behavior in the .businesslens/ model.\n')
-    writeFileSync(join(retiredSync, 'SKILL.md'), '---\nname: businesslens-sync\n---\nReconcile the BusinessLens .businesslens/ model.\n')
-    // Named like a retired skill and mentioning BusinessLens, but never recorded
-    // by a manifest: it is somebody else's and stays.
-    writeFileSync(join(lookalike, 'SKILL.md'), '---\nname: businesslens-implement\n---\nImplement the BusinessLens .businesslens/ model.\n')
-    writeFileSync(join(unrelatedSync, 'SKILL.md'), '---\nname: sync\n---\nUnrelated synchronization.\n')
+    const stale = join(skillsDir, 'businesslens-example')
+    const lookalike = join(skillsDir, 'businesslens-unowned')
+    const unrelated = join(skillsDir, 'map')
+    for (const directory of [stale, lookalike, unrelated]) {
+      mkdirSync(directory, { recursive: true })
+      writeFileSync(join(directory, 'SKILL.md'), '# Example BusinessLens skill')
+    }
     writeFileSync(join(skillsDir, '.businesslens-install.json'), JSON.stringify({
       schema: 1,
       package: 'businesslens',
-      version: '0.5.0',
+      version: '0.12.0',
       provider: 'codex',
       scope: 'project',
-      skills: ['map', 'businesslens-plan', 'businesslens-sync'],
+      skills: ['businesslens-example', 'map'],
       installedAt: '2026-01-01T00:00:00.000Z'
     }))
 
-    const result = installSkillsToTarget(
-      project,
-      { provider: providerById('codex'), scope: 'project' },
-      '9.9.9'
-    )
-
-    // `plan` folded into `ideate`, so an installed copy is a skill an agent
-    // could still invoke and must go — because the manifest says it was ours.
-    expect(result.removedLegacySkills).toEqual([
-      'businesslens-sync',
-      'businesslens-plan',
-      'map'
-    ])
-    expect(existsSync(oldMap)).toBe(false)
-    expect(existsSync(oldPlan)).toBe(false)
-    expect(existsSync(retiredSync)).toBe(false)
+    installSkillsToTarget(project, { provider: providerById('codex'), scope: 'project' }, '9.9.9')
+    expect(existsSync(stale)).toBe(false)
     expect(existsSync(lookalike)).toBe(true)
-    expect(existsSync(unrelatedSync)).toBe(true)
+    expect(existsSync(unrelated)).toBe(true)
 
-    const oldCommand = join(project, '.claude', 'commands', 'businesslens', 'init.md')
-    mkdirSync(join(project, '.claude', 'skills'), { recursive: true })
+    const command = join(project, '.claude', 'commands', 'businesslens', 'init.md')
     mkdirSync(join(project, '.claude', 'commands', 'businesslens'), { recursive: true })
-    writeFileSync(oldCommand, '# Initialize BusinessLens\n\nCreate `.businesslens/`.\n')
-    const claudeResult = installSkillsToTarget(
-      project,
-      { provider: providerById('claude'), scope: 'project' },
-      '9.9.9'
-    )
-    expect(claudeResult.removedLegacyCommands).toEqual([
-      join('.claude', 'commands', 'businesslens', 'init.md')
-    ])
-    expect(existsSync(oldCommand)).toBe(false)
+    writeFileSync(command, '# BusinessLens command owned by another tool')
+    installSkillsToTarget(project, { provider: providerById('claude'), scope: 'project' }, '9.9.9')
+    expect(existsSync(command)).toBe(true)
   })
 
   it('updates managed skills without changing product files', async () => {
@@ -293,7 +265,7 @@ describe('skill installation', () => {
     mkdirSync(join(project, '.businesslens'), { recursive: true })
     writeFileSync(product, '# Keep me\n')
 
-    expect(await runUpdate(project, { project: true })).toBe(0)
+    expect(await runUpdate(project, { scope: 'project' })).toBe(0)
     expect(readFileSync(product, 'utf8')).toBe('# Keep me\n')
     expect(existsSync(join(skillsDir, 'businesslens-verify', 'SKILL.md'))).toBe(true)
     const manifest = JSON.parse(readFileSync(manifestFile, 'utf8'))

--- a/viewer/app/package.json
+++ b/viewer/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@businesslens/local-report-viewer",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
Remove hidden historical scope/cwd options and dedicated handlers for retired commands so unsupported inputs receive normal usage errors. Installation keeps generic cleanup of stale manifest-owned `businesslens-*` skills and preserves bare-name skills and Claude command files.

Prepare 0.13.0 with synchronized package, plugin, viewer, and lockfile versions and a dated changelog. Update the release smoke test to use `--scope project` and the bug-report form to request `businesslens lint` output.

Companion to [Landing PR #69](https://github.com/businesslens/landing/pull/69), implementing businesslens/landing#62.

Validation: `npm run verify` passed (376 tests, both type checks, builds, repository and Blueprint checks). Package contents and size passed inspection; the packed 0.13.0 CLI passed the release install invocation and project/global install/update checks. All three skill validators and `claude plugin validate . --strict` passed. An additional direct plugin-manifest strict check reports the pre-existing root `CLAUDE.md` warning, unchanged from main.

Implements #52. Keep the tracking issue open until this cleanup is included in the normal PDD release.
